### PR TITLE
fix(cicd): alternative auth method for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
                 default: false
                 type: boolean
 
+permissions:
+    contents: write # For git push, creating tags and releases
+    pull-requests: write # For creating PRs (if needed)
+    packages: write # For publishing packages (if needed)
+
 jobs:
     release:
         name: Prepare and Publish Release
@@ -31,7 +36,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.RELEASE_TOKEN }}
+                  # Use the built-in token which inherits permissions from the workflow
+                  token: ${{ github.token }}
 
             - name: Install Rust
               uses: dtolnay/rust-toolchain@stable
@@ -41,8 +47,8 @@ jobs:
 
             - name: Set Git identity
               run: |
-                  git config --global user.name "Nullis Release Bot"
-                  git config --global user.email "github-actions@nullis.xyz"
+                  git config --global user.name "GitHub Actions"
+                  git config --global user.email "github-actions@github.com"
 
             - name: Install cargo-release
               run: cargo install cargo-release
@@ -67,7 +73,7 @@ jobs:
                     # Extract the current version from Cargo.toml and calculate the next version
                     CURRENT_VERSION=$(grep -m 1 'version = "' Cargo.toml | sed 's/.*version = "\(.*\)".*/\1/')
 
-                    # Simple version calculation (this is a basic implementation)
+                    # Simple version calculation
                     if [ "${{ inputs.level }}" = "patch" ]; then
                       IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
                       NEXT_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$((VERSION_PARTS[2] + 1))"
@@ -94,6 +100,8 @@ jobs:
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
                   WORKSPACE_ROOT: ${{ github.workspace }}
+                  # Use the built-in token for Git operations
+                  GIT_CREDENTIALS: https://x-access-token:${{ github.token }}@github.com
               run: |
                   echo "Running cargo release with args: ${{ steps.version_args.outputs.VERSION_ARG }} ${{ steps.version_args.outputs.DRY_RUN_ARG }}"
                   cargo release ${{ steps.version_args.outputs.VERSION_ARG }} ${{ steps.version_args.outputs.DRY_RUN_ARG }} --execute
@@ -101,7 +109,7 @@ jobs:
             - name: Create GitHub Release
               if: ${{ steps.version_args.outputs.IS_DRY_RUN == 'false' }}
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ github.token }}
               run: |
                   VERSION="${{ steps.version_args.outputs.TAG_VERSION }}"
 


### PR DESCRIPTION
This PR:

1. Removes the requirement for adding a personal access token and instead allows for inheriting permissions from the workflow.