### PR TITLE
fix(cicd): separate crate publish and gh release

### DIFF
--- a/.github/workflows/gh-tag-action.yml
+++ b/.github/workflows/gh-tag-action.yml
@@ -1,0 +1,43 @@
+name: Create GitHub Release
+
+on:
+    push:
+        tags:
+            - "v*" # Run when tag matches v*, e.g. v1.0.0
+
+permissions:
+    contents: write # For creating releases
+
+jobs:
+    build_release:
+        name: Build and Create GitHub Release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0 # Required for git-cliff to work properly
+
+            - name: Install git-cliff
+              uses: orhun/git-cliff-action@v2
+              with:
+                  config: cliff.toml
+                  args: --verbose
+
+            - name: Extract version from tag
+              id: tag_parser
+              run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+            - name: Generate release notes
+              run: |
+                  # Generate release notes for this specific tag
+                  git cliff --tag v${{ steps.tag_parser.outputs.VERSION }} --strip header > release_notes.md
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v1
+              with:
+                  name: v${{ steps.tag_parser.outputs.VERSION }}
+                  body_path: release_notes.md
+                  files: |
+                      LICENSE
+                      CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Prepare and Publish Release
 
 on:
     workflow_dispatch:
@@ -16,6 +16,10 @@ on:
                     - patch
                     - minor
                     - major
+                    - release
+                    - rc
+                    - beta
+                    - alpha
             dry-run:
                 description: "Dry run (no actual changes)"
                 required: false
@@ -23,9 +27,7 @@ on:
                 type: boolean
 
 permissions:
-    contents: write # For git push, creating tags and releases
-    pull-requests: write # For creating PRs (if needed)
-    packages: write # For publishing packages (if needed)
+    contents: write # For git push, creating tags
 
 jobs:
     release:
@@ -36,7 +38,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  # Use the built-in token which inherits permissions from the workflow
                   token: ${{ github.token }}
 
             - name: Install Rust
@@ -59,78 +60,28 @@ jobs:
                   config: cliff.toml
                   args: --verbose
 
-            - name: Set version arguments
+            - name: Build version arguments
               id: version_args
               run: |
                   if [ "${{ inputs.version }}" != "" ]; then
                     # Manual version
                     echo "VERSION_ARG=--version ${{ inputs.version }}" >> $GITHUB_OUTPUT
-                    echo "TAG_VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
                   else
-                    # Automatic version bump
+                    # Use level
                     echo "VERSION_ARG=--${{ inputs.level }}" >> $GITHUB_OUTPUT
-
-                    # Extract the current version from Cargo.toml and calculate the next version
-                    CURRENT_VERSION=$(grep -m 1 'version = "' Cargo.toml | sed 's/.*version = "\(.*\)".*/\1/')
-
-                    # Simple version calculation
-                    if [ "${{ inputs.level }}" = "patch" ]; then
-                      IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-                      NEXT_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$((VERSION_PARTS[2] + 1))"
-                    elif [ "${{ inputs.level }}" = "minor" ]; then
-                      IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-                      NEXT_VERSION="${VERSION_PARTS[0]}.$((VERSION_PARTS[1] + 1)).0"
-                    elif [ "${{ inputs.level }}" = "major" ]; then
-                      IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-                      NEXT_VERSION="$((VERSION_PARTS[0] + 1)).0.0"
-                    fi
-
-                    echo "TAG_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
                   fi
 
                   if [ "${{ inputs.dry-run }}" = "true" ]; then
                     echo "DRY_RUN_ARG=--dry-run" >> $GITHUB_OUTPUT
-                    echo "IS_DRY_RUN=true" >> $GITHUB_OUTPUT
                   else
                     echo "DRY_RUN_ARG=" >> $GITHUB_OUTPUT
-                    echo "IS_DRY_RUN=false" >> $GITHUB_OUTPUT
                   fi
 
-            - name: Run cargo-release
+            - name: Run cargo release
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
                   WORKSPACE_ROOT: ${{ github.workspace }}
-                  # Use the built-in token for Git operations
                   GIT_CREDENTIALS: https://x-access-token:${{ github.token }}@github.com
               run: |
                   echo "Running cargo release with args: ${{ steps.version_args.outputs.VERSION_ARG }} ${{ steps.version_args.outputs.DRY_RUN_ARG }}"
                   cargo release ${{ steps.version_args.outputs.VERSION_ARG }} ${{ steps.version_args.outputs.DRY_RUN_ARG }} --execute
-
-            - name: Create GitHub Release
-              if: ${{ steps.version_args.outputs.IS_DRY_RUN == 'false' }}
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              run: |
-                  VERSION="${{ steps.version_args.outputs.TAG_VERSION }}"
-
-                  # Get the content of the latest entry in CHANGELOG.md
-                  CHANGELOG_CONTENT=$(awk '/^## \[[0-9]+\.[0-9]+\.[0-9]+\]/ {if (p) {exit}; p=1; next} p' CHANGELOG.md | sed '/^## /q' | sed '$d')
-
-                  # Create GitHub release
-                  gh release create "v$VERSION" \
-                    --title "v$VERSION" \
-                    --notes "$CHANGELOG_CONTENT" \
-                    --verify-tag
-
-            - name: Create summary
-              if: ${{ steps.version_args.outputs.IS_DRY_RUN == 'false' }}
-              run: |
-                  echo "# Release Published! 🚀" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "Version: ${{ steps.version_args.outputs.TAG_VERSION }}" >> $GITHUB_STEP_SUMMARY
-                  echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "The following crates have been published to crates.io:" >> $GITHUB_STEP_SUMMARY
-                  echo "- nexum-apdu-core" >> $GITHUB_STEP_SUMMARY
-                  echo "- nexum-apdu-macros" >> $GITHUB_STEP_SUMMARY
-                  echo "- nexum-apdu-transport-pcsc" >> $GITHUB_STEP_SUMMARY
-                  echo "- nexum-apdu-globalplatform" >> $GITHUB_STEP_SUMMARY

--- a/release.toml
+++ b/release.toml
@@ -8,7 +8,8 @@ shared-version = true
 publish = true  # Enable publishing to crates.io
 pre-release-commit-message = "chore: release {{version}}"
 tag-prefix = "v"  # Use v prefix for tags
-rate-limit.existing-packages = 50
+tag-message = "Release {{version}}"
+push = true  # Make sure we push the tag
 pre-release-hook = [
     "bash",
     "-c",
@@ -16,3 +17,4 @@ pre-release-hook = [
 ]
 publish-order = ["nexum-apdu-core", "nexum-apdu-macros", "nexum-apdu-transport-pcsc", "nexum-apdu-globalplatform"]
 owners = ["github:nullisxyz:core"]
+rate-limit.existing-packages = 50


### PR DESCRIPTION
This PR:

1. Separates the workflows such that cargo-release concentrates on releasing to crates.io / docs.rs etc.
2. Subsequently it pushes the tag and this results in the github release being done.