### PR TITLE
fix: changelog for root only

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -19,6 +19,3 @@ fi
 
 command=(git cliff --workdir "$root" --config "$root/cliff.toml" "${@}")
 run_unless_dry_run "${command[@]}" --output "$root/CHANGELOG.md"
-if [ -n "$crate" ] && [ "$root" != "$crate" ]; then
-    run_unless_dry_run "${command[@]}" --include-path "$crate_glob" --output "$crate/CHANGELOG.md"
-fi


### PR DESCRIPTION
This PR:

1. Updates the changelog generation script to only generate for the root.