### PR TITLE
chore: sw constants from iso7816 and gp

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,8 +47,10 @@ pub mod prelude {
         command::ApduCommand,
         executor::Executor,
         executor::ext::{ResponseAwareExecutor, SecureChannelExecutor},
-        processor::CommandProcessor,
-        processor::secure::SecurityLevel,
+        processor::{
+            CommandProcessor,
+            secure::{SecureChannel, SecureChannelProvider, SecurityLevel},
+        },
         response::status::StatusWord,
         response::{ApduResponse, FromApduResponse},
         transport::CardTransport,

--- a/crates/globalplatform/src/commands/delete.rs
+++ b/crates/globalplatform/src/commands/delete.rs
@@ -38,20 +38,20 @@ apdu_pair! {
         response {
             ok {
                 /// Success in deleting the object
-                #[sw(0x90, 0x00)]
+                #[sw(status::SW_NO_ERROR)]
                 Success,
             }
 
             errors {
                 /// Referenced data not found
-                #[sw(status::REFERENCED_DATA_NOT_FOUND)]
+                #[sw(status::SW_REFERENCED_DATA_NOT_FOUND)]
                 #[error("Referenced data not found")]
                 ReferencedDataNotFound,
 
-                /// Security condition not satisfied
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
                 /// Other error
                 #[sw(_, _)]

--- a/crates/globalplatform/src/commands/external_authenticate.rs
+++ b/crates/globalplatform/src/commands/external_authenticate.rs
@@ -39,21 +39,21 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 Success,
             }
 
             errors {
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
-                /// Authentication method blocked (6983)
-                #[sw(status::AUTHENTICATION_METHOD_BLOCKED)]
-                #[error("Authentication method blocked")]
-                AuthenticationMethodBlocked,
+                /// Record not found
+                #[sw(status::SW_RECORD_NOT_FOUND)]
+                #[error("Record not found")]
+                RecordNotFound,
 
                 /// Other error
                 #[sw(_, _)]
@@ -128,7 +128,7 @@ mod tests {
         let response = ExternalAuthenticateResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(
             response,
-            ExternalAuthenticateResponse::SecurityConditionNotSatisfied
+            ExternalAuthenticateResponse::SecurityStatusNotSatisfied
         ));
     }
 }

--- a/crates/globalplatform/src/commands/get_response.rs
+++ b/crates/globalplatform/src/commands/get_response.rs
@@ -24,8 +24,8 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 #[payload(field = "data")]
                 Success {
                     data: Vec<u8>,
@@ -41,8 +41,8 @@ apdu_pair! {
             }
 
             errors {
-                /// Wrong length (6700)
-                #[sw(status::WRONG_LENGTH)]
+                /// Wrong length
+                #[sw(status::SW_WRONG_LENGTH)]
                 #[error("Wrong length")]
                 WrongLength,
 

--- a/crates/globalplatform/src/commands/get_status.rs
+++ b/crates/globalplatform/src/commands/get_status.rs
@@ -55,7 +55,7 @@ apdu_pair! {
 
         response {
             ok {
-                #[sw(status::SUCCESS)]
+                #[sw(status::SW_NO_ERROR)]
                 #[payload(field = "tlv_data")]
                 Success {
                     tlv_data: Vec<u8>,
@@ -71,15 +71,15 @@ apdu_pair! {
             }
 
             errors {
-                /// Referenced data not found (6A88)
-                #[sw(status::REFERENCED_DATA_NOT_FOUND)]
+                /// Referenced data not found
+                #[sw(status::SW_REFERENCED_DATA_NOT_FOUND)]
                 #[error("Referenced data not found")]
                 ReferencedDataNotFound,
 
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
                 /// Other error
                 #[sw(_, _)]

--- a/crates/globalplatform/src/commands/initialize_update.rs
+++ b/crates/globalplatform/src/commands/initialize_update.rs
@@ -31,8 +31,8 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 Success {
                     key_diversification_data: [u8; 10],
                     key_info: [u8; 2],
@@ -43,15 +43,10 @@ apdu_pair! {
             }
 
             errors {
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
-
-                /// Authentication method blocked (6983)
-                #[sw(status::AUTHENTICATION_METHOD_BLOCKED)]
-                #[error("Authentication method blocked")]
-                AuthenticationMethodBlocked,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
                 /// Other error
                 #[sw(_, _)]
@@ -64,7 +59,7 @@ apdu_pair! {
 
             custom_parse = |payload: &[u8], sw| -> Result<Self, ResponseError> {
                 match sw {
-                    status::SUCCESS => {
+                    status::SW_NO_ERROR => {
                         if payload.len() != 28 {
                             return Err(ResponseError::Parse("Response data incorrect length"));
                         }
@@ -92,8 +87,7 @@ apdu_pair! {
                             card_cryptogram,
                         })
                     }
-                    status::SECURITY_CONDITION_NOT_SATISFIED => Ok(Self::SecurityConditionNotSatisfied),
-                    status::AUTHENTICATION_METHOD_BLOCKED => Ok(Self::AuthenticationMethodBlocked),
+                    status::SW_SECURITY_STATUS_NOT_SATISFIED => Ok(Self::SecurityStatusNotSatisfied),
                     _ => Ok(Self::OtherError {
                         sw1,
                         sw2
@@ -218,7 +212,7 @@ mod tests {
         let response = InitializeUpdateResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(
             response,
-            InitializeUpdateResponse::SecurityConditionNotSatisfied
+            InitializeUpdateResponse::SecurityStatusNotSatisfied
         ));
     }
 }

--- a/crates/globalplatform/src/commands/install.rs
+++ b/crates/globalplatform/src/commands/install.rs
@@ -101,21 +101,21 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 Success,
             }
 
             errors {
-                /// Referenced data not found (6A88)
-                #[sw(status::REFERENCED_DATA_NOT_FOUND)]
+                /// Referenced data not found
+                #[sw(status::SW_REFERENCED_DATA_NOT_FOUND)]
                 #[error("Referenced data not found")]
                 ReferencedDataNotFound,
 
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
                 /// Other error
                 #[sw(_, _)]
@@ -270,7 +270,7 @@ mod tests {
         let response = InstallResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(
             response,
-            InstallResponse::SecurityConditionNotSatisfied
+            InstallResponse::SecurityStatusNotSatisfied
         ));
     }
 }

--- a/crates/globalplatform/src/commands/load.rs
+++ b/crates/globalplatform/src/commands/load.rs
@@ -34,26 +34,21 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 Success,
             }
 
             errors {
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
-                /// Wrong data length (6700)
-                #[sw(status::WRONG_LENGTH)]
-                #[error("Wrong data length")]
-                WrongDataLength,
-
-                /// File not found (6A82)
-                #[sw(status::FILE_NOT_FOUND)]
-                #[error("File not found")]
-                FileNotFound,
+                /// Wrong length
+                #[sw(status::SW_WRONG_LENGTH)]
+                #[error("Wrong length")]
+                WrongLength,
 
                 /// Other error
                 #[sw(_, _)]
@@ -108,9 +103,6 @@ mod tests {
         // Test error response
         let response_data = hex!("6982");
         let response = LoadResponse::from_bytes(&response_data).unwrap();
-        assert!(matches!(
-            response,
-            LoadResponse::SecurityConditionNotSatisfied
-        ));
+        assert!(matches!(response, LoadResponse::SecurityStatusNotSatisfied));
     }
 }

--- a/crates/globalplatform/src/commands/put_key.rs
+++ b/crates/globalplatform/src/commands/put_key.rs
@@ -6,13 +6,6 @@ use nexum_apdu_macros::apdu_pair;
 
 use crate::constants::{cla, ins, status};
 
-/// PUT KEY command P1 parameter: New key in a new version
-pub const P1_NEW_KEY_VERSION: u8 = 0x00;
-/// PUT KEY command P1 parameter: Includes key-derivation data
-pub const P1_INCLUDES_KEY_DERIVATION_DATA: u8 = 0x01;
-/// PUT KEY command P1 parameter: Key for multiple versions
-pub const P1_MULTIPLE_KEYS: u8 = 0x02;
-
 apdu_pair! {
     /// PUT KEY command for GlobalPlatform
     pub struct PutKey {
@@ -24,47 +17,47 @@ apdu_pair! {
             builders {
                 /// Create a PUT KEY command for loading a new key version
                 pub fn new_key_version(key_version: u8, key_data: impl Into<bytes::Bytes>) -> Self {
-                    Self::new(P1_NEW_KEY_VERSION, key_version).with_data(key_data.into())
+                    Self::new(0x00, key_version).with_data(key_data.into())
                 }
 
                 /// Create a PUT KEY command for replacing an existing key
                 pub fn replace_key(key_version: u8, key_data: impl Into<bytes::Bytes>) -> Self {
-                    Self::new(P1_NEW_KEY_VERSION, key_version).with_data(key_data.into())
+                    Self::new(0x00, key_version).with_data(key_data.into())
                 }
 
                 /// Create a PUT KEY command with key derivation data
                 pub fn with_derivation_data(key_version: u8, key_data: impl Into<bytes::Bytes>) -> Self {
-                    Self::new(P1_INCLUDES_KEY_DERIVATION_DATA, key_version).with_data(key_data.into())
+                    Self::new(0x01, key_version).with_data(key_data.into())
                 }
 
                 /// Create a PUT KEY command for loading multiple keys
                 pub fn multiple_keys(key_version: u8, key_data: impl Into<bytes::Bytes>) -> Self {
-                    Self::new(P1_MULTIPLE_KEYS, key_version).with_data(key_data.into())
+                    Self::new(0x02, key_version).with_data(key_data.into())
                 }
             }
         }
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 Success,
             }
 
             errors {
-                /// Referenced data not found (6A88)
-                #[sw(status::REFERENCED_DATA_NOT_FOUND)]
+                /// Referenced data not found
+                #[sw(status::SW_REFERENCED_DATA_NOT_FOUND)]
                 #[error("Referenced data not found")]
                 ReferencedDataNotFound,
 
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
-                /// Incorrect parameters in data field (6A80)
-                #[sw(status::WRONG_DATA)]
-                #[error("Incorrect parameters in data field")]
+                /// Wrong data
+                #[sw(status::SW_WRONG_DATA)]
+                #[error("Wrong data")]
                 WrongData,
 
                 /// Other error
@@ -93,7 +86,7 @@ mod tests {
 
         assert_eq!(cmd.class(), cla::GP);
         assert_eq!(cmd.instruction(), ins::PUT_KEY);
-        assert_eq!(cmd.p1(), P1_NEW_KEY_VERSION);
+        assert_eq!(cmd.p1(), 0x00);
         assert_eq!(cmd.p2(), 0x01);
         assert_eq!(cmd.data(), Some(key_data.as_ref()));
 
@@ -114,7 +107,7 @@ mod tests {
         let response = PutKeyResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(
             response,
-            PutKeyResponse::SecurityConditionNotSatisfied
+            PutKeyResponse::SecurityStatusNotSatisfied
         ));
     }
 }

--- a/crates/globalplatform/src/commands/select.rs
+++ b/crates/globalplatform/src/commands/select.rs
@@ -54,8 +54,8 @@ apdu_pair! {
 
         response {
             ok {
-                /// Success response (9000)
-                #[sw(status::SUCCESS)]
+                /// Success response
+                #[sw(status::SW_NO_ERROR)]
                 #[payload(field = "fci")]
                 Success {
                     fci: Vec<u8>,
@@ -63,18 +63,18 @@ apdu_pair! {
             }
 
             errors {
-                /// File or application not found (6A82)
-                #[sw(status::FILE_NOT_FOUND)]
+                /// File or application not found
+                #[sw(status::SW_FILE_NOT_FOUND)]
                 #[error("File or application not found")]
                 NotFound,
 
-                /// Security condition not satisfied (6982)
-                #[sw(status::SECURITY_CONDITION_NOT_SATISFIED)]
-                #[error("Security condition not satisfied")]
-                SecurityConditionNotSatisfied,
+                /// Security status not satisfied
+                #[sw(status::SW_SECURITY_STATUS_NOT_SATISFIED)]
+                #[error("Security status not satisfied")]
+                SecurityStatusNotSatisfied,
 
-                /// Incorrect parameters (6A86)
-                #[sw(status::COMMAND_NOT_ALLOWED)]
+                /// Incorrect parameters
+                #[sw(status::SW_WRONG_P1P2)]
                 #[error("Incorrect parameters")]
                 IncorrectParameters,
 

--- a/crates/globalplatform/src/constants.rs
+++ b/crates/globalplatform/src/constants.rs
@@ -111,24 +111,60 @@ pub mod delete_p2 {
 pub mod status {
     use nexum_apdu_core::StatusWord;
 
-    /// Success
-    pub const SUCCESS: StatusWord = StatusWord::new(0x90, 0x00);
-    /// Response data incomplete (SW1 = 0x61)
-    pub const RESPONSE_DATA_INCOMPLETE: u8 = 0x61;
-    /// Wrong length
-    pub const WRONG_LENGTH: StatusWord = StatusWord::new(0x67, 0x00);
-    /// Wrong data
-    pub const WRONG_DATA: StatusWord = StatusWord::new(0x6A, 0x80);
-    /// File not found
-    pub const FILE_NOT_FOUND: StatusWord = StatusWord::new(0x6A, 0x82);
-    /// Referenced data not found
-    pub const REFERENCED_DATA_NOT_FOUND: StatusWord = StatusWord::new(0x6A, 0x88);
-    /// Security condition not satisfied
-    pub const SECURITY_CONDITION_NOT_SATISFIED: StatusWord = StatusWord::new(0x69, 0x82);
-    /// Authentication method blocked
-    pub const AUTHENTICATION_METHOD_BLOCKED: StatusWord = StatusWord::new(0x69, 0x83);
-    /// Command not allowed
-    pub const COMMAND_NOT_ALLOWED: StatusWord = StatusWord::new(0x69, 0x86);
+    pub use gp::*;
+    pub use iso7816::*;
+
+    pub mod iso7816 {
+        use super::StatusWord;
+
+        /// Success (No Error)
+        pub const SW_NO_ERROR: StatusWord = StatusWord::new(0x90, 0x00);
+        /// Response data incomplete (SW1 = 0x61)
+        pub const SW_BYTES_REMAINING_00: StatusWord = StatusWord::new(0x61, 0x00);
+        /// Wrong length
+        pub const SW_WRONG_LENGTH: StatusWord = StatusWord::new(0x67, 0x00);
+        /// Wrong data
+        pub const SW_WRONG_DATA: StatusWord = StatusWord::new(0x6A, 0x80);
+        /// File not found
+        pub const SW_FILE_NOT_FOUND: StatusWord = StatusWord::new(0x6A, 0x82);
+        /// Referenced data not found (changed to RECORD_NOT_FOUND for compatibility)
+        pub const SW_RECORD_NOT_FOUND: StatusWord = StatusWord::new(0x6A, 0x83);
+        /// Security condition not satisfied
+        pub const SW_SECURITY_STATUS_NOT_SATISFIED: StatusWord = StatusWord::new(0x69, 0x82);
+        /// Authentication method blocked (changed to FILE_INVALID for compatibility)
+        pub const SW_FILE_INVALID: StatusWord = StatusWord::new(0x69, 0x83);
+        /// Command not allowed
+        pub const SW_COMMAND_NOT_ALLOWED: StatusWord = StatusWord::new(0x69, 0x86);
+        /// Incorrect parameters (P1,P2)
+        pub const SW_INCORRECT_P1P2: StatusWord = StatusWord::new(0x6A, 0x86);
+        /// Wrong parameters P1-P2
+        pub const SW_WRONG_P1P2: StatusWord = StatusWord::new(0x6B, 0x00);
+        /// Function not supported
+        pub const SW_FUNC_NOT_SUPPORTED: StatusWord = StatusWord::new(0x6A, 0x81);
+        /// Conditions of use not satisfied
+        pub const SW_CONDITIONS_NOT_SATISFIED: StatusWord = StatusWord::new(0x69, 0x85);
+        /// CLA value not supported
+        pub const SW_CLA_NOT_SUPPORTED: StatusWord = StatusWord::new(0x6E, 0x00);
+        /// INS value not supported
+        pub const SW_INS_NOT_SUPPORTED: StatusWord = StatusWord::new(0x6D, 0x00);
+        /// No precise diagnosis
+        pub const SW_UNKNOWN: StatusWord = StatusWord::new(0x6F, 0x00);
+        /// Warning, card state unchanged
+        pub const SW_WARNING_STATE_UNCHANGED: StatusWord = StatusWord::new(0x62, 0x00);
+        /// Data invalid
+        pub const SW_DATA_INVALID: StatusWord = StatusWord::new(0x69, 0x84);
+        /// Not enough memory space in the file
+        pub const SW_FILE_FULL: StatusWord = StatusWord::new(0x6A, 0x84);
+        /// Applet selection failed
+        pub const SW_APPLET_SELECT_FAILED: StatusWord = StatusWord::new(0x69, 0x99);
+    }
+
+    pub mod gp {
+        use super::StatusWord;
+
+        /// Referenced data not found
+        pub const SW_REFERENCED_DATA_NOT_FOUND: StatusWord = StatusWord::new(0x6A, 0x88);
+    }
 }
 
 /// Tags used in GlobalPlatform commands and responses


### PR DESCRIPTION
This PR:

1. Fixes all the constants status words to comply with ISO7816.
2. Added some status words that are specific to GlobalPlatform.
3. Has a minor update on the prelude.