### PR TITLE
chore: overhaul error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -282,9 +282,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -302,14 +302,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
- "windows-targets",
 ]
 
 [[package]]
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -400,9 +400,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
@@ -421,9 +421,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "overload"
@@ -569,6 +569,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -791,9 +797,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -895,27 +901,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -944,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +454,7 @@ name = "nexum-apdu-core"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "derive_more",
  "dyn-clone",
  "hex",
  "thiserror",
@@ -776,6 +798,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ bytes.workspace = true
 dyn-clone.workspace = true
 tracing = { workspace = true, features = ["attributes"] }
 hex.workspace = true
+derive_more = { workspace = true, features = ["display"] }
 
 [features]
 default = ["std"]

--- a/crates/core/src/command/mod.rs
+++ b/crates/core/src/command/mod.rs
@@ -16,7 +16,7 @@ pub type ExpectedLength = u8;
 
 use error::CommandError;
 
-use crate::{Error, prelude::SecurityLevel};
+use crate::prelude::SecurityLevel;
 
 /// Core trait for APDU commands
 pub trait ApduCommand {
@@ -277,7 +277,7 @@ impl Command {
 
 impl ApduCommand for Command {
     type Response = Bytes;
-    type ResultType = Result<Bytes, Error>;
+    type ResultType = Result<Bytes, CommandError>;
 
     fn class(&self) -> u8 {
         self.cla

--- a/crates/core/src/command/mod.rs
+++ b/crates/core/src/command/mod.rs
@@ -5,8 +5,6 @@
 
 pub mod error;
 
-use std::fmt;
-
 use bytes::{BufMut, Bytes, BytesMut};
 
 #[cfg(feature = "longer_payloads")]
@@ -24,9 +22,6 @@ use crate::prelude::SecurityLevel;
 pub trait ApduCommand {
     /// Response type returned when this command is executed
     type Response: TryFrom<Bytes>;
-
-    /// Error type that can occur during execution
-    type Error: Into<crate::Error> + fmt::Debug;
 
     /// Command class (CLA)
     fn class(&self) -> u8;
@@ -279,7 +274,6 @@ impl Command {
 
 impl ApduCommand for Command {
     type Response = Bytes;
-    type Error = CommandError;
 
     fn class(&self) -> u8 {
         self.cla

--- a/crates/core/src/command/mod.rs
+++ b/crates/core/src/command/mod.rs
@@ -16,12 +16,15 @@ pub type ExpectedLength = u8;
 
 use error::CommandError;
 
-use crate::prelude::SecurityLevel;
+use crate::{Error, prelude::SecurityLevel};
 
 /// Core trait for APDU commands
 pub trait ApduCommand {
-    /// Response type returned when this command is executed
+    /// Response enum type returned when this command is executed
     type Response: TryFrom<Bytes>;
+
+    /// Result type for this command (like SelectResult = Result<SelectOk, SelectError>)
+    type ResultType;
 
     /// Command class (CLA)
     fn class(&self) -> u8;
@@ -274,6 +277,7 @@ impl Command {
 
 impl ApduCommand for Command {
     type Response = Bytes;
+    type ResultType = Result<Bytes, Error>;
 
     fn class(&self) -> u8 {
         self.cla

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,79 +1,30 @@
-//! Unified error type for APDU operations
+//! Default error type for APDU operations
+use crate::{
+    processor::{ProcessorError, SecureProtocolError},
+    response::error::ResponseError,
+    transport::TransportError,
+};
 
-use crate::response::status::StatusWord;
-
-/// The main error type for APDU operations
+/// APDU Core error type
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Transport-related errors
+    /// Error from response processing
     #[error(transparent)]
-    Transport(#[from] crate::transport::error::TransportError),
+    Response(#[from] ResponseError),
 
-    /// Command-related errors
+    /// Error from command processor
     #[error(transparent)]
-    Command(#[from] crate::command::error::CommandError),
+    Processor(#[from] ProcessorError),
 
-    /// Response-related errors
+    /// Error from transport layer
     #[error(transparent)]
-    Response(#[from] crate::response::error::ResponseError),
+    Transport(#[from] TransportError),
 
-    /// Status errors (for status words)
+    /// Error from secure channel protocol
     #[error(transparent)]
-    Status(#[from] crate::response::error::StatusError),
+    SecureProtocol(#[from] SecureProtocolError),
 
-    /// Processor-related errors
-    #[error(transparent)]
-    Processor(#[from] crate::processor::error::ProcessorError),
-
-    /// Secure protocol related errors
-    #[error(transparent)]
-    SecureProtocol(#[from] crate::processor::error::SecureProtocolError),
-
-    /// Parse errors
-    #[error("Parse error: {0}")]
-    Parse(&'static str),
-
-    /// Other errors with message (for std environments)
-    #[error("{0}")]
-    Other(String),
+    /// Other
+    #[error("Other error: {0}")]
+    Other(&'static str),
 }
-
-impl Error {
-    /// Create a new error with the given status word
-    pub const fn status(sw1: u8, sw2: u8) -> Self {
-        Self::Status(crate::response::error::StatusError::new(sw1, sw2))
-    }
-
-    /// Create a new error with the given status word and message
-    pub const fn status_with_message(sw1: u8, sw2: u8, message: &'static str) -> Self {
-        Self::Status(crate::response::error::StatusError::with_message(
-            sw1, sw2, message,
-        ))
-    }
-
-    /// Check if this error has the given status word
-    pub const fn has_status(&self, sw: u16) -> bool {
-        if let Self::Status(status_error) = self {
-            status_error.status_word().to_u16() == sw
-        } else {
-            false
-        }
-    }
-
-    /// Get the status word if this is a status error
-    pub const fn status_word(&self) -> Option<StatusWord> {
-        if let Self::Status(status_error) = self {
-            Some(status_error.status_word())
-        } else {
-            None
-        }
-    }
-
-    /// Create a generic other error
-    pub fn other<S: Into<String>>(message: S) -> Self {
-        Self::Other(message.into())
-    }
-}
-
-/// Result type for APDU operations
-pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/core/src/executor/ext.rs
+++ b/crates/core/src/executor/ext.rs
@@ -24,9 +24,13 @@ pub trait ResponseAwareExecutor: Executor {
 pub trait SecureChannelExecutor: Executor {
     /// Open a secure channel with the card
     ///
-    /// This establishes a secure channel using the provided secure channel provider
-    /// and the requested security level.
+    /// This establishes a secure channel using the provided secure channel provider.
     fn open_secure_channel(&mut self, provider: &dyn SecureChannelProvider) -> crate::Result<()>;
+
+    /// Check if a secure channel is currently established
+    fn has_secure_channel(&self) -> bool {
+        self.security_level().has_mac_protection() || self.security_level().is_encrypted()
+    }
 }
 
 // Implementation for CardExecutor

--- a/crates/core/src/executor/ext.rs
+++ b/crates/core/src/executor/ext.rs
@@ -6,9 +6,11 @@
 use crate::{
     Bytes,
     executor::Executor,
-    processor::secure::SecureChannelProvider,
+    processor::{SecureProtocolError, secure::SecureChannelProvider},
     transport::{CardTransport, error::TransportError},
 };
+
+use super::{ApduExecutorErrors, CardExecutor};
 
 /// Extension trait for executors that support access to the last response
 pub trait ResponseAwareExecutor: Executor {
@@ -17,7 +19,7 @@ pub trait ResponseAwareExecutor: Executor {
     /// Returns the raw bytes of the last response received from the card.
     /// This is useful for protocols that need to access the raw response
     /// for cryptographic operations.
-    fn last_response(&self) -> crate::Result<&Bytes>;
+    fn last_response(&self) -> Result<&Bytes, TransportError>;
 }
 
 /// Extension trait for executors that support secure channels
@@ -25,7 +27,10 @@ pub trait SecureChannelExecutor: Executor {
     /// Open a secure channel with the card
     ///
     /// This establishes a secure channel using the provided secure channel provider.
-    fn open_secure_channel(&mut self, provider: &dyn SecureChannelProvider) -> crate::Result<()>;
+    fn open_secure_channel(
+        &mut self,
+        provider: &dyn SecureChannelProvider,
+    ) -> Result<(), SecureProtocolError>;
 
     /// Check if a secure channel is currently established
     fn has_secure_channel(&self) -> bool {
@@ -33,22 +38,19 @@ pub trait SecureChannelExecutor: Executor {
     }
 }
 
-// Implementation for CardExecutor
-impl<T: CardTransport> ResponseAwareExecutor for super::CardExecutor<T> {
-    fn last_response(&self) -> crate::Result<&Bytes> {
-        self.last_response().map_or_else(
-            || {
-                Err(TransportError::Other(
-                    "No last response available".to_string(),
-                ))?
-            },
-            Ok,
-        )
+// Implementation for CardExecutor with any error type
+impl<T: CardTransport, E: ApduExecutorErrors> ResponseAwareExecutor for CardExecutor<T, E> {
+    fn last_response(&self) -> Result<&Bytes, TransportError> {
+        self.last_response()
+            .ok_or_else(|| TransportError::Other("No last response available".to_string()))
     }
 }
 
-impl<T: CardTransport> SecureChannelExecutor for super::CardExecutor<T> {
-    fn open_secure_channel(&mut self, provider: &dyn SecureChannelProvider) -> crate::Result<()> {
-        Self::open_secure_channel(self, provider)
+impl<T: CardTransport, E: ApduExecutorErrors> SecureChannelExecutor for CardExecutor<T, E> {
+    fn open_secure_channel(
+        &mut self,
+        provider: &dyn SecureChannelProvider,
+    ) -> Result<(), SecureProtocolError> {
+        self.open_secure_channel(provider)
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,19 +23,16 @@ pub use bytes::{Bytes, BytesMut};
 
 // Main modules
 pub mod command;
+pub mod error;
 pub mod executor;
 pub mod processor;
 pub mod response;
 pub mod transport;
 
-// Core error types
-mod error;
-pub use error::{Error, Result};
-
-// Re-exports for common types
 pub use command::{ApduCommand, Command};
-pub use executor::ext::{ResponseAwareExecutor, SecureChannelExecutor}; // New re-exports
-pub use executor::{CardExecutor, Executor};
+pub use error::Error;
+pub use executor::ext::{ResponseAwareExecutor, SecureChannelExecutor};
+pub use executor::{ApduExecutorErrors, CardExecutor, Executor};
 pub use response::status::StatusWord;
 pub use response::{ApduResponse, Response, utils};
 pub use transport::CardTransport;
@@ -43,10 +40,10 @@ pub use transport::CardTransport;
 /// Prelude module containing commonly used traits and types
 pub mod prelude {
     pub use crate::{
-        Bytes, BytesMut, Command, Error, Response, Result,
+        Bytes, BytesMut, Command, Error, Response,
         command::ApduCommand,
-        executor::Executor,
         executor::ext::{ResponseAwareExecutor, SecureChannelExecutor},
+        executor::{ApduExecutorErrors, Executor},
         processor::{
             CommandProcessor,
             secure::{SecureChannel, SecureChannelProvider, SecurityLevel},
@@ -56,7 +53,6 @@ pub mod prelude {
         transport::CardTransport,
     };
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/processor/error.rs
+++ b/crates/core/src/processor/error.rs
@@ -69,25 +69,3 @@ pub enum SecureProtocolError {
     #[error("{0}")]
     Other(String),
 }
-
-impl SecureProtocolError {
-    /// Create a new protocol error
-    pub const fn protocol(message: &'static str) -> Self {
-        Self::Protocol(message)
-    }
-
-    /// Create a new authentication failed error
-    pub const fn authentication_failed(message: &'static str) -> Self {
-        Self::AuthenticationFailed(message)
-    }
-
-    /// Create a new session error
-    pub const fn session(message: &'static str) -> Self {
-        Self::Session(message)
-    }
-
-    /// Create a general other error
-    pub fn other<S: Into<String>>(message: S) -> Self {
-        Self::Other(message.into())
-    }
-}

--- a/crates/core/src/processor/error.rs
+++ b/crates/core/src/processor/error.rs
@@ -11,15 +11,11 @@ pub enum ProcessorError {
 
     /// Invalid response
     #[error(transparent)]
-    InvalidResponse(#[from] ResponseError),
+    Response(#[from] ResponseError),
 
-    /// Authentication failed
-    #[error("Authentication failed: {0}")]
-    AuthenticationFailed(&'static str),
-
-    /// Session error
-    #[error("Session error: {0}")]
-    Session(&'static str),
+    /// Secure channel error
+    #[error(transparent)]
+    SecureChannel(#[from] SecureProtocolError),
 
     /// Protocol error
     #[error("Protocol error: {0}")]
@@ -35,16 +31,6 @@ pub enum ProcessorError {
 }
 
 impl ProcessorError {
-    /// Create a new authentication failed error
-    pub const fn authentication_failed(message: &'static str) -> Self {
-        Self::AuthenticationFailed(message)
-    }
-
-    /// Create a new session error
-    pub const fn session(message: &'static str) -> Self {
-        Self::Session(message)
-    }
-
     /// Create a new protocol error
     pub const fn protocol(message: &'static str) -> Self {
         Self::Protocol(message)
@@ -63,9 +49,21 @@ pub enum SecureProtocolError {
     #[error("Protocol error: {0}")]
     Protocol(&'static str),
 
-    /// Processor error
-    #[error("Processor error: {0}")]
-    Processor(#[from] ProcessorError),
+    /// Response error
+    #[error("Response error: {0}")]
+    Response(#[from] ResponseError),
+
+    /// Insufficient security level
+    #[error("Current security level is insufficient")]
+    InsufficientSecurityLevel,
+
+    /// Authentication failed
+    #[error("Authentication failed: {0}")]
+    AuthenticationFailed(&'static str),
+
+    /// Session error
+    #[error("Session error: {0}")]
+    Session(&'static str),
 
     /// Other error with message (for std environments)
     #[error("{0}")]
@@ -78,18 +76,18 @@ impl SecureProtocolError {
         Self::Protocol(message)
     }
 
+    /// Create a new authentication failed error
+    pub const fn authentication_failed(message: &'static str) -> Self {
+        Self::AuthenticationFailed(message)
+    }
+
+    /// Create a new session error
+    pub const fn session(message: &'static str) -> Self {
+        Self::Session(message)
+    }
+
     /// Create a general other error
     pub fn other<S: Into<String>>(message: S) -> Self {
         Self::Other(message.into())
-    }
-}
-
-impl From<SecureProtocolError> for ProcessorError {
-    fn from(error: SecureProtocolError) -> Self {
-        match error {
-            SecureProtocolError::Protocol(message) => Self::Protocol(message),
-            SecureProtocolError::Processor(error) => Self::Other(error.to_string()),
-            SecureProtocolError::Other(message) => Self::Other(message),
-        }
     }
 }

--- a/crates/core/src/processor/mod.rs
+++ b/crates/core/src/processor/mod.rs
@@ -14,10 +14,8 @@ use dyn_clone::DynClone;
 use secure::SecurityLevel;
 use tracing::{debug, trace};
 
-use crate::command::Command;
-use crate::command::ExpectedLength;
-use crate::response::Response;
-use crate::response::utils;
+use crate::command::{Command, ExpectedLength};
+use crate::response::{Response, utils};
 use crate::transport::CardTransport;
 use crate::{ApduCommand, ApduResponse};
 pub use error::{ProcessorError, SecureProtocolError};
@@ -33,7 +31,7 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> core::result::Result<Response, ProcessorError> {
+    ) -> Result<Response, ProcessorError> {
         trace!(
             command = ?command,
             processor = std::any::type_name::<Self>(),
@@ -65,7 +63,7 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> core::result::Result<Response, ProcessorError>;
+    ) -> Result<Response, ProcessorError>;
 
     /// Get the security level provided by this processor
     fn security_level(&self) -> SecurityLevel {
@@ -90,7 +88,7 @@ impl CommandProcessor for IdentityProcessor {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> core::result::Result<Response, ProcessorError> {
+    ) -> Result<Response, ProcessorError> {
         // Convert command to bytes and send
         let command_bytes = command.to_bytes();
         let response_bytes = transport.transmit_raw(&command_bytes)?;
@@ -125,7 +123,7 @@ impl CommandProcessor for GetResponseProcessor {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> core::result::Result<Response, ProcessorError> {
+    ) -> Result<Response, ProcessorError> {
         // Convert command to bytes
         let command_bytes = command.to_bytes();
 

--- a/crates/core/src/processor/mod.rs
+++ b/crates/core/src/processor/mod.rs
@@ -14,21 +14,18 @@ use dyn_clone::DynClone;
 use secure::SecurityLevel;
 use tracing::{debug, trace};
 
+use crate::Result;
 use crate::command::Command;
 use crate::command::ExpectedLength;
 use crate::response::Response;
 use crate::response::utils;
 use crate::transport::CardTransport;
-use crate::transport::error::TransportError;
 use crate::{ApduCommand, ApduResponse};
 pub use error::{ProcessorError, SecureProtocolError};
 
 /// Trait for command processors which transform commands
 /// before sending them to the transport
 pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
-    /// Error type returned by the processor
-    type Error: Into<crate::Error> + fmt::Debug;
-
     /// Process a command through this processor
     ///
     /// This method takes a command, potentially transforms it, sends it through
@@ -36,8 +33,8 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
     fn process_command(
         &mut self,
         command: &Command,
-        transport: &mut dyn CardTransport<Error = TransportError>,
-    ) -> Result<Response, Self::Error> {
+        transport: &mut dyn CardTransport,
+    ) -> Result<Response> {
         trace!(
             command = ?command,
             processor = std::any::type_name::<Self>(),
@@ -68,8 +65,8 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
     fn do_process_command(
         &mut self,
         command: &Command,
-        transport: &mut dyn CardTransport<Error = TransportError>,
-    ) -> Result<Response, Self::Error>;
+        transport: &mut dyn CardTransport,
+    ) -> Result<Response>;
 
     /// Get the security level provided by this processor
     fn security_level(&self) -> SecurityLevel {
@@ -83,26 +80,24 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
 }
 
 // Enable cloning for boxed processors
-dyn_clone::clone_trait_object!(CommandProcessor<Error = ProcessorError>);
+dyn_clone::clone_trait_object!(CommandProcessor);
 
 /// Identity processor that doesn't modify commands
 #[derive(Debug, Clone)]
 pub struct IdentityProcessor;
 
 impl CommandProcessor for IdentityProcessor {
-    type Error = ProcessorError;
-
     fn do_process_command(
         &mut self,
         command: &Command,
-        transport: &mut dyn CardTransport<Error = TransportError>,
-    ) -> Result<Response, Self::Error> {
+        transport: &mut dyn CardTransport,
+    ) -> Result<Response> {
         // Convert command to bytes and send
         let command_bytes = command.to_bytes();
         let response_bytes = transport.transmit_raw(&command_bytes)?;
 
         // Parse response
-        Response::from_bytes(&response_bytes).map_err(ProcessorError::from)
+        Response::from_bytes(&response_bytes).map_err(Into::into)
     }
 }
 
@@ -127,13 +122,11 @@ impl Default for GetResponseProcessor {
 }
 
 impl CommandProcessor for GetResponseProcessor {
-    type Error = ProcessorError;
-
     fn do_process_command(
         &mut self,
         command: &Command,
-        transport: &mut dyn CardTransport<Error = TransportError>,
-    ) -> Result<Response, Self::Error> {
+        transport: &mut dyn CardTransport,
+    ) -> Result<Response> {
         // Convert command to bytes
         let command_bytes = command.to_bytes();
 
@@ -184,7 +177,7 @@ impl CommandProcessor for GetResponseProcessor {
             }
 
             if chains >= self.max_chains && current_sw1 == 0x61 {
-                return Err(ProcessorError::ChainLimitExceeded);
+                return Err(ProcessorError::ChainLimitExceeded).map_err(Into::into);
             }
 
             // Construct final response with accumulated data and final status word

--- a/crates/core/src/processor/mod.rs
+++ b/crates/core/src/processor/mod.rs
@@ -14,7 +14,6 @@ use dyn_clone::DynClone;
 use secure::SecurityLevel;
 use tracing::{debug, trace};
 
-use crate::Result;
 use crate::command::Command;
 use crate::command::ExpectedLength;
 use crate::response::Response;
@@ -34,7 +33,7 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> Result<Response> {
+    ) -> core::result::Result<Response, ProcessorError> {
         trace!(
             command = ?command,
             processor = std::any::type_name::<Self>(),
@@ -66,7 +65,7 @@ pub trait CommandProcessor: Send + Sync + fmt::Debug + DynClone {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> Result<Response>;
+    ) -> core::result::Result<Response, ProcessorError>;
 
     /// Get the security level provided by this processor
     fn security_level(&self) -> SecurityLevel {
@@ -91,7 +90,7 @@ impl CommandProcessor for IdentityProcessor {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> Result<Response> {
+    ) -> core::result::Result<Response, ProcessorError> {
         // Convert command to bytes and send
         let command_bytes = command.to_bytes();
         let response_bytes = transport.transmit_raw(&command_bytes)?;
@@ -126,7 +125,7 @@ impl CommandProcessor for GetResponseProcessor {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> Result<Response> {
+    ) -> core::result::Result<Response, ProcessorError> {
         // Convert command to bytes
         let command_bytes = command.to_bytes();
 

--- a/crates/core/src/processor/mod.rs
+++ b/crates/core/src/processor/mod.rs
@@ -176,7 +176,7 @@ impl CommandProcessor for GetResponseProcessor {
             }
 
             if chains >= self.max_chains && current_sw1 == 0x61 {
-                return Err(ProcessorError::ChainLimitExceeded).map_err(Into::into);
+                return Err(ProcessorError::ChainLimitExceeded);
             }
 
             // Construct final response with accumulated data and final status word

--- a/crates/core/src/processor/secure.rs
+++ b/crates/core/src/processor/secure.rs
@@ -325,7 +325,7 @@ impl CommandProcessor for MockSecureChannel {
         transport: &mut dyn CardTransport,
     ) -> Result<Response, ProcessorError> {
         if !self.is_established() {
-            return Err(SecureProtocolError::session("Secure channel not established").into());
+            return Err(SecureProtocolError::Session("Secure channel not established").into());
         }
 
         // Create a secured version of the command

--- a/crates/core/src/processor/secure.rs
+++ b/crates/core/src/processor/secure.rs
@@ -227,7 +227,7 @@ impl CommandProcessor for BaseSecureChannel {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> crate::Result<Response> {
+    ) -> Result<Response, ProcessorError> {
         warn!("Using BaseSecureChannel which does not implement any protection");
 
         let command_bytes = command.to_bytes();
@@ -287,7 +287,7 @@ impl CommandProcessor for MockSecureChannel {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> crate::Result<Response> {
+    ) -> Result<Response, ProcessorError> {
         if !self.is_established() {
             return Err(ProcessorError::session("Secure channel not established").into());
         }

--- a/crates/core/src/response/error.rs
+++ b/crates/core/src/response/error.rs
@@ -1,5 +1,7 @@
 //! Error types specific to APDU responses
 
+use crate::transport::TransportError;
+
 use super::status::StatusWord;
 
 /// Error for status words in APDU responses
@@ -47,6 +49,10 @@ impl StatusError {
 /// Error for APDU response processing
 #[derive(Debug, thiserror::Error)]
 pub enum ResponseError {
+    /// Underlying transport has caused an error
+    #[error(transparent)]
+    Transport(#[from] TransportError),
+
     /// Incomplete response (less than 2 bytes)
     #[error("Incomplete response")]
     Incomplete,

--- a/crates/core/src/response/error.rs
+++ b/crates/core/src/response/error.rs
@@ -1,26 +1,19 @@
 //! Error types specific to APDU responses
 
+use derive_more::Display;
+
 use crate::transport::TransportError;
 
 use super::status::StatusWord;
 
 /// Error for status words in APDU responses
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error, Display)]
+#[display("Status error {}, message: {:?}", status, message)]
 pub struct StatusError {
     /// Status word that caused the error
     pub status: StatusWord,
     /// Optional error message
     pub message: Option<&'static str>,
-}
-
-impl std::fmt::Display for StatusError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Status error {}", self.status)?;
-        if let Some(msg) = self.message {
-            write!(f, ": {}", msg)?;
-        }
-        Ok(())
-    }
 }
 
 impl StatusError {
@@ -31,19 +24,6 @@ impl StatusError {
             message: None,
         }
     }
-
-    /// Create a new status error with a message
-    pub const fn with_message(sw1: u8, sw2: u8, message: &'static str) -> Self {
-        Self {
-            status: StatusWord::new(sw1, sw2),
-            message: Some(message),
-        }
-    }
-
-    /// Get the status word
-    pub const fn status_word(&self) -> StatusWord {
-        self.status
-    }
 }
 
 /// Error for APDU response processing
@@ -52,10 +32,6 @@ pub enum ResponseError {
     /// Underlying transport has caused an error
     #[error(transparent)]
     Transport(#[from] TransportError),
-
-    /// Incomplete response (less than 2 bytes)
-    #[error("Incomplete response")]
-    Incomplete,
 
     /// Parse error
     #[error("Parse error: {0}")]
@@ -72,44 +48,11 @@ pub enum ResponseError {
     /// Status word error with custom message
     #[error("Response error: {0}")]
     Message(String),
-
-    /// Other error
-    #[error("Unknown response error")]
-    Other,
 }
 
 impl ResponseError {
     /// Create a new status error
     pub const fn status(sw1: u8, sw2: u8) -> Self {
         Self::Status(StatusError::new(sw1, sw2))
-    }
-
-    /// Create a new status error with a message
-    pub const fn status_with_message(sw1: u8, sw2: u8, message: &'static str) -> Self {
-        Self::Status(StatusError::with_message(sw1, sw2, message))
-    }
-
-    /// Create a parse error with a message
-    pub const fn parse(message: &'static str) -> Self {
-        Self::Parse(message)
-    }
-
-    /// Create an invalid response error with a message
-    pub const fn invalid_response(message: &'static str) -> Self {
-        Self::Parse(message)
-    }
-
-    /// Check if this error has the given status word
-    pub const fn has_status(&self, sw: u16) -> bool {
-        if let Self::Status(status_error) = self {
-            status_error.status_word().to_u16() == sw
-        } else {
-            false
-        }
-    }
-
-    /// Create a message error
-    pub fn message<S: Into<String>>(message: S) -> Self {
-        Self::Message(message.into())
     }
 }

--- a/crates/core/src/response/mod.rs
+++ b/crates/core/src/response/mod.rs
@@ -7,8 +7,6 @@ pub mod error;
 pub mod status;
 pub mod utils;
 
-use std::fmt;
-
 use bytes::{BufMut, Bytes, BytesMut};
 use tracing::trace;
 
@@ -17,9 +15,6 @@ use status::StatusWord;
 
 /// Trait for APDU responses
 pub trait ApduResponse: Sized {
-    /// Error type returned by the response
-    type Error: Into<crate::Error> + fmt::Debug;
-
     /// Get the response payload data
     fn payload(&self) -> &[u8];
 
@@ -32,16 +27,13 @@ pub trait ApduResponse: Sized {
     }
 
     /// Create from raw APDU response data
-    fn from_bytes(data: &[u8]) -> Result<Self, Self::Error>;
+    fn from_bytes(data: &[u8]) -> Result<Self, ResponseError>;
 }
 
 /// Trait for types that can be created from APDU response data
 pub trait FromApduResponse: Sized {
-    /// Error that can occur during conversion
-    type Error: Into<crate::Error> + fmt::Debug;
-
     /// Convert raw APDU response data to this type
-    fn from_response(data: &[u8]) -> core::result::Result<Self, Self::Error>;
+    fn from_response(data: &[u8]) -> Result<Self, ResponseError>;
 }
 
 /// Basic APDU response structure
@@ -101,27 +93,25 @@ impl Response {
     }
 
     /// Convert to a bytes result
-    pub fn into_bytes_result(self) -> core::result::Result<Bytes, StatusError> {
+    pub fn into_bytes_result(self) -> Result<Bytes, StatusError> {
         if self.is_success() {
             Ok(self.payload)
         } else {
-            Err(StatusError::new(self.status.sw1, self.status.sw2))
+            Err(StatusError::new(self.status.sw1, self.status.sw2).into())
         }
     }
 
     /// Convert to a bytes reference result
-    pub fn as_bytes_result(&self) -> core::result::Result<&[u8], StatusError> {
+    pub fn as_bytes_result(&self) -> Result<&[u8], ResponseError> {
         if self.is_success() {
             Ok(&self.payload)
         } else {
-            Err(StatusError::new(self.status.sw1, self.status.sw2))
+            Err(StatusError::new(self.status.sw1, self.status.sw2).into())
         }
     }
 }
 
 impl ApduResponse for Response {
-    type Error = ResponseError;
-
     fn payload(&self) -> &[u8] {
         &self.payload
     }
@@ -130,7 +120,7 @@ impl ApduResponse for Response {
         self.status
     }
 
-    fn from_bytes(data: &[u8]) -> Result<Self, Self::Error> {
+    fn from_bytes(data: &[u8]) -> Result<Self, ResponseError> {
         Self::from_bytes(data)
     }
 }
@@ -138,7 +128,7 @@ impl ApduResponse for Response {
 impl TryFrom<&[u8]> for Response {
     type Error = ResponseError;
 
-    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+    fn try_from(data: &[u8]) -> Result<Self, ResponseError> {
         Self::from_bytes(data)
     }
 }
@@ -147,7 +137,7 @@ impl TryFrom<&[u8]> for Response {
 impl TryFrom<Bytes> for Response {
     type Error = ResponseError;
 
-    fn try_from(data: Bytes) -> Result<Self, Self::Error> {
+    fn try_from(data: Bytes) -> Result<Self, ResponseError> {
         Self::from_bytes(&data)
     }
 }

--- a/crates/core/src/response/mod.rs
+++ b/crates/core/src/response/mod.rs
@@ -203,6 +203,6 @@ mod tests {
         let error = Response::error((0x6A, 0x82));
         let result = error.into_bytes_result();
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().status_word().to_u16(), 0x6A82);
+        assert_eq!(result.unwrap_err().status.to_u16(), 0x6A82);
     }
 }

--- a/crates/core/src/response/mod.rs
+++ b/crates/core/src/response/mod.rs
@@ -97,7 +97,7 @@ impl Response {
         if self.is_success() {
             Ok(self.payload)
         } else {
-            Err(StatusError::new(self.status.sw1, self.status.sw2).into())
+            Err(StatusError::new(self.status.sw1, self.status.sw2))
         }
     }
 

--- a/crates/core/src/response/utils.rs
+++ b/crates/core/src/response/utils.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 pub fn extract_response_parts(data: &[u8]) -> Result<((u8, u8), &[u8]), ResponseError> {
     if data.len() < 2 {
         debug!("Response too short: {} bytes", data.len());
-        return Err(ResponseError::Incomplete);
+        return Err(ResponseError::BufferTooSmall);
     }
 
     let len = data.len();

--- a/crates/core/src/transport/error.rs
+++ b/crates/core/src/transport/error.rs
@@ -19,58 +19,11 @@ pub enum TransportError {
     #[error("Buffer too small")]
     BufferTooSmall,
 
-    /// Driver error (with code)
-    #[error("Driver error code: {0}")]
-    Driver(i32),
-
-    /// Status word error
-    #[error("Status word error: {0:#06X}")]
-    StatusWord(u16),
-
     /// Timeout error
     #[error("Operation timed out")]
     Timeout,
 
-    /// Cancelled operation
-    #[error("Operation cancelled")]
-    Cancelled,
-
     /// Other error with message
     #[error("{0}")]
     Other(String),
-}
-
-impl TransportError {
-    /// Create a new status word error
-    pub const fn status_word(sw: u16) -> Self {
-        Self::StatusWord(sw)
-    }
-
-    /// Create a new status word error from individual bytes
-    pub const fn status_word_bytes(sw1: u8, sw2: u8) -> Self {
-        Self::StatusWord(((sw1 as u16) << 8) | (sw2 as u16))
-    }
-
-    /// Create a new driver error
-    pub const fn driver(code: i32) -> Self {
-        Self::Driver(code)
-    }
-
-    /// Check if this is a status word error
-    pub const fn is_status_word(&self) -> bool {
-        matches!(self, Self::StatusWord(_))
-    }
-
-    /// Get the status word if this is a status word error
-    pub const fn get_status_word(&self) -> Option<u16> {
-        match self {
-            Self::StatusWord(sw) => Some(*sw),
-            _ => None,
-        }
-    }
-
-    /// Create a general other error
-    pub fn other<S: Into<String>>(message: S) -> Self {
-        Self::Other(message.into())
-    }
 }

--- a/crates/core/src/transport/mod.rs
+++ b/crates/core/src/transport/mod.rs
@@ -18,9 +18,7 @@ use tracing::{debug, trace};
 pub trait CardTransport: Send + Sync + fmt::Debug {
     /// Send raw APDU bytes to card and return response bytes
     ///
-    /// This method should handle the low-level communication with the card
-    /// but should not interpret the contents or handle protocol-specific
-    /// operations like GET RESPONSE.
+    /// This is the lowest level transmission method that should only deal with raw bytes.
     fn transmit_raw(&mut self, command: &[u8]) -> Result<Bytes, TransportError> {
         trace!(command = ?hex::encode(command), "Transmitting raw command");
         let result = self.do_transmit_raw(command);
@@ -36,7 +34,6 @@ pub trait CardTransport: Send + Sync + fmt::Debug {
     }
 
     /// Internal implementation of transmit_raw
-    /// This is the method that concrete implementations should override
     fn do_transmit_raw(&mut self, command: &[u8]) -> Result<Bytes, TransportError>;
 
     /// Check if the transport is connected to a physical card

--- a/crates/core/src/transport/mod.rs
+++ b/crates/core/src/transport/mod.rs
@@ -85,13 +85,13 @@ impl MockTransport {
 impl CardTransport for MockTransport {
     fn do_transmit_raw(&mut self, command: &[u8]) -> Result<Bytes, TransportError> {
         if !self.connected {
-            return Err(TransportError::Connection)?;
+            return Err(TransportError::Connection);
         }
 
         self.commands.push(Bytes::copy_from_slice(command));
 
         if self.responses.is_empty() {
-            return Err(TransportError::Transmission)?;
+            return Err(TransportError::Transmission);
         }
 
         // Either clone the single response or take the next one

--- a/crates/globalplatform/examples/delete_package.rs
+++ b/crates/globalplatform/examples/delete_package.rs
@@ -3,9 +3,8 @@
 //! This example connects to a PC/SC reader, selects the ISD, opens a secure channel,
 //! and deletes a package by AID.
 
-use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::GlobalPlatform;
-use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
+use nexum_apdu_globalplatform::DefaultGlobalPlatform;
+use nexum_apdu_transport_pcsc::PcscDeviceManager;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Check command line arguments
@@ -46,13 +45,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Using reader: {}", reader.name());
 
-    // Connect to the reader
-    let config = PcscConfig::default();
-    let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let executor = CardExecutor::new(transport);
-
     // Create GlobalPlatform instance
-    let mut gp = GlobalPlatform::new(executor);
+    let mut gp = DefaultGlobalPlatform::connect(reader.name())?;
 
     // Select the Card Manager
     println!("Selecting Card Manager...");

--- a/crates/globalplatform/examples/delete_package.rs
+++ b/crates/globalplatform/examples/delete_package.rs
@@ -56,11 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Select the Card Manager
     println!("Selecting Card Manager...");
-    let select_response = gp.select_card_manager()?;
-    if !select_response.is_success() {
-        println!("Failed to select Card Manager!");
-        return Ok(());
-    }
+    gp.select_card_manager()??;
     println!("Card Manager selected successfully.");
 
     // Open secure channel

--- a/crates/globalplatform/examples/install_cap.rs
+++ b/crates/globalplatform/examples/install_cap.rs
@@ -62,11 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Select the Card Manager
     println!("Selecting Card Manager...");
-    let select_response = gp.select_card_manager()?;
-    if !select_response.is_success() {
-        println!("Failed to select Card Manager!");
-        return Ok(());
-    }
+    let _ = gp.select_card_manager()??;
     println!("Card Manager selected successfully.");
 
     // Open secure channel

--- a/crates/globalplatform/examples/install_cap.rs
+++ b/crates/globalplatform/examples/install_cap.rs
@@ -6,9 +6,8 @@
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::{GlobalPlatform, load::LoadCommandStream};
-use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
+use nexum_apdu_globalplatform::{DefaultGlobalPlatform, load::LoadCommandStream};
+use nexum_apdu_transport_pcsc::PcscDeviceManager;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the tracing logger with env_format and ansi
@@ -52,13 +51,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Using reader: {}", reader.name());
 
-    // Connect to the reader
-    let config = PcscConfig::default();
-    let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let executor = CardExecutor::new(transport);
-
     // Create GlobalPlatform instance
-    let mut gp = GlobalPlatform::new(executor);
+    let mut gp = DefaultGlobalPlatform::connect(reader.name())?;
 
     // Select the Card Manager
     println!("Selecting Card Manager...");

--- a/crates/globalplatform/examples/list_applications.rs
+++ b/crates/globalplatform/examples/list_applications.rs
@@ -4,7 +4,7 @@
 //! and lists all applications on the card.
 
 use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::GlobalPlatform;
+use nexum_apdu_globalplatform::{Error, GlobalPlatform, commands::get_status::tlv_data};
 use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
 use tracing_subscriber::EnvFilter;
 
@@ -47,11 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Select the Card Manager
     println!("Selecting Card Manager...");
-    let select_response = gp.select_card_manager()?;
-    if !select_response.is_success() {
-        println!("Failed to select Card Manager!");
-        return Ok(());
-    }
+    let _ = gp.select_card_manager()??;
     println!("Card Manager selected successfully.");
 
     // Open secure channel
@@ -66,35 +62,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get applications status
     println!("Getting applications status...");
-    match gp.get_applications_status() {
-        Ok(response) => {
-            if let Some(tlv_data) = response.tlv_data() {
-                println!("Applications:");
-                print_applications(tlv_data);
-            } else {
-                println!("No application data returned.");
-            }
-        }
-        Err(e) => {
-            println!("Failed to get applications status: {:?}", e);
-        }
-    }
+    let response = gp
+        .get_applications_status()?
+        .map_err(|e| Error::Msg(e.to_string()))?;
+
+    let data = tlv_data(response);
+    println!("Applications:");
+    print_applications(data.as_slice());
 
     // Get load files status
     println!("\nGetting load files status...");
-    match gp.get_load_files_status() {
-        Ok(response) => {
-            if let Some(tlv_data) = response.tlv_data() {
-                println!("Load files:");
-                print_load_files(tlv_data);
-            } else {
-                println!("No load file data returned.");
-            }
-        }
-        Err(e) => {
-            println!("Failed to get load files status: {:?}", e);
-        }
-    }
+    let response = gp
+        .get_load_files_status()?
+        .map_err(|e| Error::Msg(e.to_string()))?;
+
+    let data = tlv_data(response);
+    println!("Load files:");
+    print_load_files(data.as_slice());
 
     Ok(())
 }

--- a/crates/globalplatform/examples/list_applications.rs
+++ b/crates/globalplatform/examples/list_applications.rs
@@ -3,9 +3,8 @@
 //! This example connects to a PC/SC reader, selects the ISD, opens a secure channel,
 //! and lists all applications on the card.
 
-use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::{Error, GlobalPlatform, commands::get_status::tlv_data};
-use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
+use nexum_apdu_globalplatform::{DefaultGlobalPlatform, commands::get_status::tlv_data};
+use nexum_apdu_transport_pcsc::PcscDeviceManager;
 use tracing_subscriber::EnvFilter;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -37,13 +36,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Using reader: {}", reader.name());
 
-    // Connect to the reader
-    let config = PcscConfig::default();
-    let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let executor = CardExecutor::new(transport);
-
     // Create GlobalPlatform instance
-    let mut gp = GlobalPlatform::new(executor);
+    let mut gp = DefaultGlobalPlatform::connect(reader.name())?;
 
     // Select the Card Manager
     println!("Selecting Card Manager...");
@@ -62,9 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get applications status
     println!("Getting applications status...");
-    let response = gp
-        .get_applications_status()?
-        .map_err(|e| Error::Msg(e.to_string()))?;
+    let response = gp.get_applications_status()??;
 
     let data = tlv_data(response);
     println!("Applications:");
@@ -72,9 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get load files status
     println!("\nGetting load files status...");
-    let response = gp
-        .get_load_files_status()?
-        .map_err(|e| Error::Msg(e.to_string()))?;
+    let response = gp.get_load_files_status()??;
 
     let data = tlv_data(response);
     println!("Load files:");

--- a/crates/globalplatform/examples/select_and_open_channel.rs
+++ b/crates/globalplatform/examples/select_and_open_channel.rs
@@ -2,9 +2,8 @@
 //!
 //! This example connects to a PC/SC reader, selects the ISD, and opens a secure channel.
 
-use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::{GlobalPlatform, commands::select::SelectOk};
-use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
+use nexum_apdu_globalplatform::{DefaultGlobalPlatform, commands::select::SelectOk};
+use nexum_apdu_transport_pcsc::PcscDeviceManager;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a PC/SC device manager
@@ -39,13 +38,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\nUsing reader: {}", reader.name());
 
-    // Connect to the reader
-    let config = PcscConfig::default();
-    let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let executor = CardExecutor::new(transport);
-
     // Create GlobalPlatform instance
-    let mut gp = GlobalPlatform::new(executor);
+    let mut gp = DefaultGlobalPlatform::connect(reader.name())?;
 
     // Select the Card Manager
     println!("Selecting Card Manager...");

--- a/crates/globalplatform/examples/select_and_open_channel.rs
+++ b/crates/globalplatform/examples/select_and_open_channel.rs
@@ -3,7 +3,7 @@
 //! This example connects to a PC/SC reader, selects the ISD, and opens a secure channel.
 
 use nexum_apdu_core::CardExecutor;
-use nexum_apdu_globalplatform::GlobalPlatform;
+use nexum_apdu_globalplatform::{GlobalPlatform, commands::select::SelectOk};
 use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -49,30 +49,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Select the Card Manager
     println!("Selecting Card Manager...");
-    let select_response = gp.select_card_manager()?;
+    let select_response = gp.select_card_manager()??;
 
-    if select_response.is_success() {
-        println!("Card Manager selected successfully.");
+    let SelectOk::Success { fci } = select_response;
+    println!("Card Manager selected successfully.");
 
-        // Print FCI information if available
-        println!("FCI data: {}", hex::encode_upper(select_response.fci()));
+    // Print FCI information if available
+    println!("FCI data: {}", hex::encode_upper(fci));
 
-        // Open secure channel
-        println!("\nOpening secure channel...");
-        match gp.open_secure_channel() {
-            Ok(_) => {
-                println!("Secure channel established successfully!");
-                println!("Card is ready for management operations.");
-            }
-            Err(e) => {
-                println!("Failed to open secure channel: {:?}", e);
-                println!("The card might be using non-default keys or might not support SCP02.");
-            }
+    // Open secure channel
+    println!("\nOpening secure channel...");
+    match gp.open_secure_channel() {
+        Ok(_) => {
+            println!("Secure channel established successfully!");
+            println!("Card is ready for management operations.");
         }
-    } else {
-        println!("Failed to select Card Manager!");
-        println!("Response: {:?}", select_response);
-        println!("This might not be a GlobalPlatform-compatible card.");
+        Err(e) => {
+            println!("Failed to open secure channel: {:?}", e);
+            println!("The card might be using non-default keys or might not support SCP02.");
+        }
     }
 
     Ok(())

--- a/crates/globalplatform/src/application.rs
+++ b/crates/globalplatform/src/application.rs
@@ -78,17 +78,15 @@ where
         // Create SELECT command
         let cmd = SelectCommand::with_aid(aid.to_vec());
 
-        // Execute command and map errors
-        match self.executor.execute(&cmd) {
-            Ok(response) => {
-                // Store response for possible later use
-                if let Ok(raw_response) = self.executor.last_response() {
-                    self.last_response = Some(Bytes::copy_from_slice(raw_response));
-                }
-                Ok(response)
-            }
-            Err(e) => Err(Error::from(e)),
+        // Execute command using typed execution flow
+        let response = self.executor.execute(&cmd)?;
+
+        // Store response for possible later use
+        if let Ok(raw_response) = self.executor.last_response() {
+            self.last_response = Some(Bytes::copy_from_slice(raw_response));
         }
+
+        Ok(response)
     }
 
     /// Open a secure channel with default keys
@@ -322,7 +320,7 @@ where
         let get_data_cmd = Command::new(0x80, 0xCA, 0x00, 0x66).with_le(0x00);
 
         // Execute and get the response
-        let response = self.executor.transmit(&get_data_cmd.to_bytes())?;
+        let response = self.executor.transmit_raw(&get_data_cmd.to_bytes())?;
 
         // Check if the command was successful
         if response.len() >= 2 {

--- a/crates/globalplatform/src/application.rs
+++ b/crates/globalplatform/src/application.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 
 use nexum_apdu_core::ApduCommand;
 
-use cipher::Key;
 use nexum_apdu_core::prelude::{Executor, ResponseAwareExecutor, SecureChannelExecutor};
 use nexum_apdu_core::{Bytes, Command, StatusWord};
 
@@ -15,7 +14,6 @@ use crate::commands::delete::DeleteResult;
 use crate::commands::get_status::GetStatusResult;
 use crate::commands::install::InstallResult;
 use crate::commands::select::SelectResult;
-use crate::crypto::Scp02;
 use crate::{
     Error, Result,
     commands::{DeleteCommand, GetStatusCommand, InstallCommand, LoadCommand, SelectCommand},
@@ -24,23 +22,6 @@ use crate::{
     secure_channel::create_secure_channel_provider,
     session::{Keys, Session},
 };
-
-/// Default GlobalPlatform keys
-#[derive(Debug, Clone, Copy)]
-pub struct DefaultKeys;
-
-impl DefaultKeys {
-    /// Create a new set of default GlobalPlatform keys
-    pub fn new() -> Keys {
-        // Default GlobalPlatform test key
-        let key = [
-            0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D,
-            0x4E, 0x4F,
-        ];
-        let key = Key::<Scp02>::from_slice(&key);
-        Keys::from_single_key(*key)
-    }
-}
 
 /// GlobalPlatform card management application
 #[allow(missing_debug_implementations)]
@@ -92,7 +73,7 @@ where
 
     /// Open a secure channel with default keys
     pub fn open_secure_channel(&mut self) -> Result<()> {
-        self.open_secure_channel_with_keys(&DefaultKeys::new())
+        self.open_secure_channel_with_keys(&Keys::default())
     }
 
     /// Open a secure channel with specific keys and security level

--- a/crates/globalplatform/src/application.rs
+++ b/crates/globalplatform/src/application.rs
@@ -58,8 +58,6 @@ where
 impl<E> GlobalPlatform<E>
 where
     E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-    nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-    Error: From<E::Error>,
 {
     /// Create a new GlobalPlatform instance
     pub const fn new(executor: E) -> Self {
@@ -381,9 +379,10 @@ mod tests {
     }
 
     impl nexum_apdu_core::transport::CardTransport for TestTransport {
-        type Error = TransportError;
-
-        fn do_transmit_raw(&mut self, _command: &[u8]) -> std::result::Result<Bytes, Self::Error> {
+        fn do_transmit_raw(
+            &mut self,
+            _command: &[u8],
+        ) -> std::result::Result<Bytes, TransportError> {
             if self.responses.is_empty() {
                 return Err(TransportError::Transmission)?;
             }
@@ -399,7 +398,7 @@ mod tests {
             true
         }
 
-        fn reset(&mut self) -> std::result::Result<(), Self::Error> {
+        fn reset(&mut self) -> std::result::Result<(), TransportError> {
             Ok(())
         }
     }

--- a/crates/globalplatform/src/bin/gp-tools.rs
+++ b/crates/globalplatform/src/bin/gp-tools.rs
@@ -8,9 +8,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use hex::FromHex;
 use nexum_apdu_core::CardExecutor;
 use nexum_apdu_globalplatform::crypto::Scp02;
-use nexum_apdu_globalplatform::{
-    DefaultKeys, GlobalPlatform, Keys, load::LoadCommandStream, operations,
-};
+use nexum_apdu_globalplatform::{GlobalPlatform, Keys, load::LoadCommandStream, operations};
 use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -182,7 +180,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Open secure channel with appropriate keys
     println!("Opening secure channel...");
     let keys = if cli.default_keys {
-        DefaultKeys::new()
+        Keys::default()
     } else if let Some(key_str) = cli.keys {
         let key_bytes = Vec::from_hex(key_str.replace(' ', ""))?;
         if key_bytes.len() != 16 {
@@ -194,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Keys::from_single_key(*key)
     } else {
         // Default to test keys
-        DefaultKeys::new()
+        Keys::default()
     };
 
     match gp.open_secure_channel_with_keys(&keys) {

--- a/crates/globalplatform/src/bin/gp-tools.rs
+++ b/crates/globalplatform/src/bin/gp-tools.rs
@@ -176,11 +176,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Select the card manager
     println!("Selecting Card Manager...");
-    let select_response = gp.select_card_manager()?;
-    if !select_response.is_success() {
-        eprintln!("Failed to select Card Manager!");
-        return Ok(());
-    }
+    let _ = gp.select_card_manager()??;
     println!("Card Manager selected successfully.");
 
     // Open secure channel with appropriate keys

--- a/crates/globalplatform/src/bin/gp-tools.rs
+++ b/crates/globalplatform/src/bin/gp-tools.rs
@@ -7,6 +7,7 @@ use cipher::Key;
 use clap::{Parser, Subcommand, ValueEnum};
 use hex::FromHex;
 use nexum_apdu_core::CardExecutor;
+use nexum_apdu_globalplatform::Error;
 use nexum_apdu_globalplatform::crypto::Scp02;
 use nexum_apdu_globalplatform::{GlobalPlatform, Keys, load::LoadCommandStream, operations};
 use nexum_apdu_transport_pcsc::{PcscConfig, PcscDeviceManager};
@@ -167,7 +168,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to the card
     let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let executor = CardExecutor::new(transport);
+    let executor: CardExecutor<_, Error> = CardExecutor::new(transport);
 
     // Create GlobalPlatform instance
     let mut gp = GlobalPlatform::new(executor);

--- a/crates/globalplatform/src/commands/get_response.rs
+++ b/crates/globalplatform/src/commands/get_response.rs
@@ -57,7 +57,7 @@ apdu_pair! {
 
             methods {
                 /// Get the response data
-                pub fn data(&self) -> Option<&[u8]> {
+                pub const fn data(&self) -> Option<&Vec<u8>> {
                     match self {
                         Self::Success { data } | Self::MoreData { data, .. } => Some(data),
                         _ => None,
@@ -110,7 +110,10 @@ mod tests {
         let response = GetResponseResponse::from_bytes(&response_data).unwrap();
 
         assert!(matches!(response, GetResponseResponse::Success { .. }));
-        assert_eq!(response.data(), Some(&hex!("01020304")[..]));
+        assert_eq!(
+            response.data(),
+            Some(hex!("01020304")[..].to_vec().as_ref())
+        );
         assert!(!response.has_more_data());
         assert_eq!(response.remaining_bytes(), None);
 
@@ -119,7 +122,10 @@ mod tests {
         let response = GetResponseResponse::from_bytes(&response_data).unwrap();
 
         assert!(matches!(response, GetResponseResponse::MoreData { .. }));
-        assert_eq!(response.data(), Some(&hex!("01020304")[..]));
+        assert_eq!(
+            response.data(),
+            Some(hex!("01020304")[..].to_vec().as_ref())
+        );
         assert!(response.has_more_data());
         assert_eq!(response.remaining_bytes(), Some(0xFF));
     }

--- a/crates/globalplatform/src/commands/get_status.rs
+++ b/crates/globalplatform/src/commands/get_status.rs
@@ -92,7 +92,7 @@ apdu_pair! {
 
             methods {
                 /// Get the TLV data
-                pub fn tlv_data(&self) -> Option<&[u8]> {
+                pub const fn tlv_data(&self) -> Option<&Vec<u8>> {
                     match self {
                         Self::Success { tlv_data } | Self::MoreData { tlv_data, .. } => Some(tlv_data),
                         _ => None,
@@ -303,7 +303,7 @@ mod tests {
 
         let response = GetStatusResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(response, GetStatusResponse::Success { .. }));
-        assert_eq!(response.tlv_data(), Some(tlv_data.as_ref()));
+        assert_eq!(response.tlv_data(), Some(tlv_data.to_vec().as_ref()));
         assert!(!response.has_more_data());
 
         // Test more data available
@@ -314,7 +314,7 @@ mod tests {
 
         let response = GetStatusResponse::from_bytes(&response_data).unwrap();
         assert!(matches!(response, GetStatusResponse::MoreData { .. }));
-        assert_eq!(response.tlv_data(), Some(tlv_data.as_ref()));
+        assert_eq!(response.tlv_data(), Some(tlv_data.to_vec().as_ref()));
         assert!(response.has_more_data());
         assert_eq!(response.remaining_bytes(), Some(0x20));
     }

--- a/crates/globalplatform/src/lib.rs
+++ b/crates/globalplatform/src/lib.rs
@@ -48,8 +48,6 @@ pub mod operations {
     pub fn connect_and_setup<E>(executor: E) -> Result<GlobalPlatform<E>>
     where
         E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-        nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-        Error: From<E::Error>,
     {
         // Create GlobalPlatform instance
         let mut gp = GlobalPlatform::new(executor);
@@ -69,8 +67,6 @@ pub mod operations {
     ) -> Result<Vec<crate::commands::get_status::ApplicationInfo>>
     where
         E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-        nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-        Error: From<E::Error>,
     {
         let response = gp.get_applications_status()?;
         Ok(response.parse_applications())
@@ -82,8 +78,6 @@ pub mod operations {
     ) -> Result<Vec<crate::commands::get_status::LoadFileInfo>>
     where
         E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-        nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-        Error: From<E::Error>,
     {
         let response = gp.get_load_files_status()?;
         Ok(response.parse_load_files())
@@ -93,8 +87,6 @@ pub mod operations {
     pub fn delete_package<E>(gp: &mut GlobalPlatform<E>, aid: &[u8]) -> Result<()>
     where
         E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-        nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-        Error: From<E::Error>,
     {
         // Delete the package and all related applications
         let response = gp.delete_object_and_related(aid)?;
@@ -116,8 +108,6 @@ pub mod operations {
     ) -> Result<()>
     where
         E: Executor + ResponseAwareExecutor + SecureChannelExecutor,
-        nexum_apdu_core::response::error::ResponseError: Into<E::Error>,
-        Error: From<E::Error>,
     {
         // First analyze the CAP file to extract package and applet AIDs
         let cap_info = gp.analyze_cap_file(&cap_path)?;

--- a/crates/globalplatform/src/lib.rs
+++ b/crates/globalplatform/src/lib.rs
@@ -27,9 +27,6 @@ pub use session::{Keys, Session};
 // Re-export from nexum_apdu_core for convenience
 pub use nexum_apdu_core::{ResponseAwareExecutor, SecureChannelExecutor};
 
-// Export DefaultKeys for easy initialization
-pub use application::DefaultKeys;
-
 // Export main commands
 pub use commands::{
     DeleteCommand, DeleteResponse, GetStatusCommand, GetStatusResponse, InitializeUpdateCommand,

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -7,12 +7,15 @@ use std::fmt;
 
 use bytes::{BufMut, BytesMut};
 use cipher::{Iv, Key};
-use nexum_apdu_core::processor::{
-    CommandProcessor, ProcessorError,
-    secure::{SecureChannel, SecureChannelProvider, SecurityLevel},
-};
 use nexum_apdu_core::transport::CardTransport;
 use nexum_apdu_core::{ApduCommand, Command, Response};
+use nexum_apdu_core::{
+    processor::{
+        CommandProcessor, ProcessorError, SecureProtocolError,
+        secure::{SecureChannel, SecureChannelProvider, SecurityLevel},
+    },
+    response::error::ResponseError,
+};
 use rand::RngCore;
 use tracing::{debug, trace, warn};
 
@@ -39,11 +42,11 @@ pub struct SCP02Wrapper {
 
 impl SCP02Wrapper {
     /// Create a new SCP02 wrapper with the specified MAC key
-    pub fn new(key: Key<Scp02>) -> Result<Self, Error> {
-        Ok(Self {
+    pub fn new(key: Key<Scp02>) -> Self {
+        Self {
             mac_key: key,
             icv: Default::default(),
-        })
+        }
     }
 
     /// Wrap an APDU command by adding a MAC
@@ -136,15 +139,15 @@ impl fmt::Debug for GPSecureChannel {
 
 impl GPSecureChannel {
     /// Create a new secure channel with the specified session
-    pub fn new(session: Session) -> Result<Self, Error> {
-        let wrapper = SCP02Wrapper::new(*session.keys().mac())?;
+    pub fn new(session: Session) -> Self {
+        let wrapper = SCP02Wrapper::new(*session.keys().mac());
 
-        Ok(Self {
+        Self {
             session,
             wrapper,
             established: false,
             security_level: SecurityLevel::default(),
-        })
+        }
     }
 
     /// Get a reference to the session
@@ -156,7 +159,7 @@ impl GPSecureChannel {
     pub fn authenticate(
         &mut self,
         transport: &mut dyn CardTransport,
-    ) -> Result<(), ProcessorError> {
+    ) -> Result<(), SecureProtocolError> {
         // Create EXTERNAL AUTHENTICATE command
         let auth_cmd = ExternalAuthenticateCommand::from_challenges(
             self.session.keys().enc(),
@@ -174,7 +177,7 @@ impl GPSecureChannel {
         // Send wrapped command
         let response_bytes = transport
             .transmit_raw(&wrapped_cmd.to_bytes())
-            .map_err(ProcessorError::from)?;
+            .map_err(ResponseError::from)?;
 
         // Parse response
         let auth_response = ExternalAuthenticateResponse::from_bytes(&response_bytes)?;
@@ -182,7 +185,7 @@ impl GPSecureChannel {
         // Check if successful
         if !matches!(auth_response, ExternalAuthenticateResponse::Success) {
             self.established = false;
-            return Err(ProcessorError::authentication_failed(
+            return Err(SecureProtocolError::authentication_failed(
                 "EXTERNAL AUTHENTICATE failed",
             ));
         }
@@ -204,7 +207,7 @@ impl CommandProcessor for GPSecureChannel {
         transport: &mut dyn CardTransport,
     ) -> Result<Response, ProcessorError> {
         if !self.established {
-            return Err(ProcessorError::session("Secure channel not established"));
+            return Err(SecureProtocolError::session("Secure channel not established").into());
         }
 
         trace!(command = ?command, "Processing command with GlobalPlatform SCP02");
@@ -235,16 +238,16 @@ impl SecureChannel for GPSecureChannel {
         self.established
     }
 
-    fn close(&mut self) -> nexum_apdu_core::Result<()> {
+    fn close(&mut self) -> Result<(), SecureProtocolError> {
         debug!("Closing GlobalPlatform SCP02 secure channel");
         self.established = false;
         self.security_level = SecurityLevel::none();
         Ok(())
     }
 
-    fn reestablish(&mut self) -> nexum_apdu_core::Result<()> {
+    fn reestablish(&mut self) -> Result<(), SecureProtocolError> {
         warn!("Reestablish not implemented for GlobalPlatform SCP02");
-        Err(ProcessorError::session(
+        Err(SecureProtocolError::session(
             "Cannot reestablish GlobalPlatform SCP02 channel - a new session must be created",
         )
         .into())
@@ -274,28 +277,33 @@ impl SecureChannelProvider for GPSecureChannelProvider {
     fn create_secure_channel(
         &self,
         transport: &mut dyn CardTransport,
-    ) -> nexum_apdu_core::Result<Box<dyn CommandProcessor>> {
+    ) -> Result<Box<dyn CommandProcessor>, SecureProtocolError> {
         // Generate host challenge
         let mut host_challenge = HostChallenge::default();
         rand::rng().fill_bytes(&mut host_challenge);
 
         // Step 1: Send INITIALIZE UPDATE
         let init_cmd = InitializeUpdateCommand::with_challenge(host_challenge.to_vec());
-        let response_bytes = transport.transmit_raw(&init_cmd.to_bytes())?;
+        let response_bytes = transport
+            .transmit_raw(&init_cmd.to_bytes())
+            .map_err(ResponseError::from)?;
 
         // Parse response
         let init_response = InitializeUpdateResponse::from_bytes(&response_bytes)?;
 
         // Check for successful response
         if !matches!(init_response, InitializeUpdateResponse::Success { .. }) {
-            return Err(ProcessorError::authentication_failed("INITIALIZE UPDATE failed").into());
+            return Err(SecureProtocolError::AuthenticationFailed(
+                "INITIALIZE UPDATE failed",
+            ));
         }
 
         // Create session directly from response
-        let session = Session::from_response(&self.keys, &init_response, host_challenge)?;
+        let session = Session::from_response(&self.keys, &init_response, host_challenge)
+            .map_err(|e| SecureProtocolError::other(e.to_string()))?;
 
         // Create secure channel with session (not yet established)
-        let mut channel = GPSecureChannel::new(session)?;
+        let mut channel = GPSecureChannel::new(session);
 
         // Step 2: Authenticate the channel (sends EXTERNAL AUTHENTICATE)
         channel.authenticate(transport)?;
@@ -375,7 +383,7 @@ mod tests {
     #[test]
     fn test_wrap_command() {
         let mac_key = Key::<Scp02>::from_slice(hex!("2983ba77d709c2daa1e6000abccac951").as_slice());
-        let mut wrapper = SCP02Wrapper::new(*mac_key).unwrap();
+        let mut wrapper = SCP02Wrapper::new(*mac_key);
 
         // Verify initial ICV
         assert_eq!(wrapper.icv(), &Iv::<Scp02>::default());
@@ -419,7 +427,7 @@ mod tests {
         let session = create_test_session();
 
         // Create secure channel
-        let mut channel = GPSecureChannel::new(session).unwrap();
+        let mut channel = GPSecureChannel::new(session);
 
         // Mark it as established for the test
         channel.established = true;
@@ -454,7 +462,7 @@ mod tests {
         let session = create_test_session();
 
         // Create secure channel (not established yet)
-        let mut channel = GPSecureChannel::new(session).unwrap();
+        let mut channel = GPSecureChannel::new(session);
 
         // Call authenticate
         let result = channel.authenticate(&mut transport);

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -202,7 +202,7 @@ impl CommandProcessor for GPSecureChannel {
         &mut self,
         command: &Command,
         transport: &mut dyn CardTransport,
-    ) -> nexum_apdu_core::Result<Response> {
+    ) -> Result<Response, ProcessorError> {
         if !self.established {
             return Err(ProcessorError::session("Secure channel not established").into());
         }

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -185,7 +185,7 @@ impl GPSecureChannel {
         // Check if successful
         if !matches!(auth_response, ExternalAuthenticateResponse::Success) {
             self.established = false;
-            return Err(SecureProtocolError::authentication_failed(
+            return Err(SecureProtocolError::AuthenticationFailed(
                 "EXTERNAL AUTHENTICATE failed",
             ));
         }
@@ -207,7 +207,7 @@ impl CommandProcessor for GPSecureChannel {
         transport: &mut dyn CardTransport,
     ) -> Result<Response, ProcessorError> {
         if !self.established {
-            return Err(SecureProtocolError::session("Secure channel not established").into());
+            return Err(SecureProtocolError::Session("Secure channel not established").into());
         }
 
         trace!(command = ?command, "Processing command with GlobalPlatform SCP02");
@@ -247,7 +247,7 @@ impl SecureChannel for GPSecureChannel {
 
     fn reestablish(&mut self) -> Result<(), SecureProtocolError> {
         warn!("Reestablish not implemented for GlobalPlatform SCP02");
-        Err(SecureProtocolError::session(
+        Err(SecureProtocolError::Session(
             "Cannot reestablish GlobalPlatform SCP02 channel - a new session must be created",
         )
         .into())
@@ -300,7 +300,7 @@ impl SecureChannelProvider for GPSecureChannelProvider {
 
         // Create session directly from response
         let session = Session::from_response(&self.keys, &init_response, host_challenge)
-            .map_err(|e| SecureProtocolError::other(e.to_string()))?;
+            .map_err(|e| SecureProtocolError::Other(e.to_string()))?;
 
         // Create secure channel with session (not yet established)
         let mut channel = GPSecureChannel::new(session);

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -204,7 +204,7 @@ impl CommandProcessor for GPSecureChannel {
         transport: &mut dyn CardTransport,
     ) -> Result<Response, ProcessorError> {
         if !self.established {
-            return Err(ProcessorError::session("Secure channel not established").into());
+            return Err(ProcessorError::session("Secure channel not established"));
         }
 
         trace!(command = ?command, "Processing command with GlobalPlatform SCP02");

--- a/crates/globalplatform/src/session.rs
+++ b/crates/globalplatform/src/session.rs
@@ -25,6 +25,18 @@ pub struct Keys {
     mac: Key<Scp02>,
 }
 
+impl Default for Keys {
+    fn default() -> Self {
+        // Default GlobalPlatform test key
+        let key = [
+            0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D,
+            0x4E, 0x4F,
+        ];
+        let key = Key::<Scp02>::from_slice(&key);
+        Self::from_single_key(*key)
+    }
+}
+
 impl Keys {
     /// Create a new key set with the specified encryption and MAC keys
     pub const fn new(enc: Key<Scp02>, mac: Key<Scp02>) -> Self {

--- a/crates/macros/examples/custom_parser.rs
+++ b/crates/macros/examples/custom_parser.rs
@@ -211,7 +211,7 @@ fn main() {
             Ok(VerifyPinOk::AttemptsRemaining { count }) => {
                 println!("PIN attempts remaining: {}", count);
                 if count == 0 {
-                    return Err(ApduError::other("PIN is blocked"));
+                    return Err(ApduError::Other("PIN is blocked"));
                 }
             }
             _ => {

--- a/crates/macros/src/command.rs
+++ b/crates/macros/src/command.rs
@@ -1,5 +1,3 @@
-// File: apdu/crates/macros/src/command.rs
-
 //! Command parsing and expansion logic
 
 use proc_macro2::{Span, TokenStream};
@@ -149,7 +147,6 @@ pub(crate) fn expand_command(
 
         impl nexum_apdu_core::ApduCommand for #command_name {
             type Response = #response_name;
-            type Error = nexum_apdu_core::response::error::ResponseError;
 
             fn class(&self) -> u8 {
                 #cla

--- a/crates/macros/src/command.rs
+++ b/crates/macros/src/command.rs
@@ -96,6 +96,7 @@ pub(crate) fn expand_command(
     vis: &Visibility,
     command_name: &Ident,
     response_name: &Ident,
+    result_name: &Ident,
 ) -> Result<TokenStream, syn::Error> {
     let cla = &command.cla;
     let ins = &command.ins;
@@ -147,6 +148,7 @@ pub(crate) fn expand_command(
 
         impl nexum_apdu_core::ApduCommand for #command_name {
             type Response = #response_name;
+            type ResultType = #result_name;
 
             fn class(&self) -> u8 {
                 #cla

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -152,15 +152,20 @@ fn expand_apdu_pair(pair: &ApduPair) -> Result<TokenStream2, TokenStream2> {
         pair.struct_name.span(),
     );
 
-    // Expand command and response definitions
-    let command_tokens =
-        command::expand_command(&pair.command, &pair.vis, &command_name, &response_name)
-            .map_err(|e| error_tokens("Error expanding command", e))?;
-
     // Get the response tokens and associated type names
     let (response_tokens, ok_name, error_name, result_name) =
         response::expand_response(&pair.response, &pair.vis, &response_name, &command_name)
             .map_err(|e| error_tokens("Error expanding response", e))?;
+
+    // Expand command and response definitions
+    let command_tokens = command::expand_command(
+        &pair.command,
+        &pair.vis,
+        &command_name,
+        &response_name,
+        &result_name,
+    )
+    .map_err(|e| error_tokens("Error expanding command", e))?;
 
     let attrs = &pair.attrs;
 

--- a/crates/macros/src/response.rs
+++ b/crates/macros/src/response.rs
@@ -874,7 +874,7 @@ pub(crate) fn expand_response(
             /// Parse response from raw bytes
             pub fn from_bytes(bytes: &[u8]) -> core::result::Result<Self, nexum_apdu_core::response::error::ResponseError> {
                 if bytes.len() < 2 {
-                    return Err(nexum_apdu_core::response::error::ResponseError::Incomplete);
+                    return Err(nexum_apdu_core::response::error::ResponseError::BufferTooSmall);
                 }
 
                 let sw1 = bytes[bytes.len() - 2];

--- a/crates/pcsc/examples/apdu_shell.rs
+++ b/crates/pcsc/examples/apdu_shell.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Selecting AID: {}", hex::encode_upper(&aid));
 
                 // Execute command
-                match executor.transmit(&select_cmd.to_bytes()) {
+                match executor.transmit_raw(&select_cmd.to_bytes()) {
                     Ok(response_bytes) => {
                         // Clone to avoid borrow issues with Response::from_bytes
                         let response_data = response_bytes.to_vec();
@@ -174,7 +174,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
 
                         // Execute raw APDU
-                        match executor.transmit(&command_bytes) {
+                        match executor.transmit_raw(&command_bytes) {
                             Ok(response_bytes) => {
                                 // Clone to avoid borrow issues with Response::from_bytes
                                 let response_data = response_bytes.to_vec();

--- a/crates/pcsc/examples/apdu_shell.rs
+++ b/crates/pcsc/examples/apdu_shell.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Connect to the reader
     let config = PcscConfig::default();
     let transport = manager.open_reader_with_config(reader.name(), config)?;
-    let mut executor = CardExecutor::new(transport);
+    let mut executor: CardExecutor<PcscTransport> = CardExecutor::new(transport);
 
     println!("\nAPDU Shell - Enter commands in hex format or 'help' for assistance");
     println!("Examples:");

--- a/crates/pcsc/examples/connect.rs
+++ b/crates/pcsc/examples/connect.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect to the reader
     let transport = manager.open_reader(reader.name())?;
-    let mut executor = CardExecutor::new(transport);
+    let mut executor: CardExecutor<PcscTransport> = CardExecutor::new(transport);
 
     // Get ATR if available
     let transport = executor.transport();

--- a/crates/pcsc/examples/connect.rs
+++ b/crates/pcsc/examples/connect.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let cmd_bytes = hex::decode(hex)?;
         println!("\nSending {}: {}", name, hex);
 
-        match executor.transmit(&cmd_bytes) {
+        match executor.transmit_raw(&cmd_bytes) {
             Ok(response_bytes) => {
                 let response_data = response_bytes.to_vec();
                 match Response::from_bytes(&response_data) {
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let select_cmd = Command::new_with_data(0x00, 0xA4, 0x04, 0x00, aid);
 
     println!("\nSelecting VISA AID:");
-    match executor.transmit(&select_cmd.to_bytes()) {
+    match executor.transmit_raw(&select_cmd.to_bytes()) {
         Ok(response) => {
             println!(
                 "Response: {} bytes, status: {}",

--- a/crates/pcsc/examples/select_aid.rs
+++ b/crates/pcsc/examples/select_aid.rs
@@ -36,7 +36,7 @@ fn select_aid(
     executor: &mut CardExecutor<impl nexum_apdu_core::CardTransport>,
     aid_hex: &str,
 ) -> Result<String, Error> {
-    let aid = hex::decode(aid_hex).map_err(|_| Error::Parse("Invalid AID hex"))?;
+    let aid = hex::decode(aid_hex).map_err(|_| Error::Other("Invalid AID hex"))?;
 
     // Create SELECT command with AID
     let select_cmd = Command::new_with_data(0x00, 0xA4, 0x04, 0x00, aid.clone());

--- a/crates/pcsc/examples/select_aid.rs
+++ b/crates/pcsc/examples/select_aid.rs
@@ -1,7 +1,6 @@
 //! Example showing how to select an application by AID
 
 use nexum_apdu_core::prelude::Executor;
-use nexum_apdu_core::transport::error::TransportError;
 use nexum_apdu_core::{ApduCommand, ApduResponse, CardExecutor, Command, Error};
 use nexum_apdu_transport_pcsc::PcscDeviceManager;
 use std::thread::sleep;
@@ -34,7 +33,7 @@ impl AidRegistry {
 
 /// Select an application by AID
 fn select_aid(
-    executor: &mut CardExecutor<impl nexum_apdu_core::CardTransport<Error = TransportError>>,
+    executor: &mut CardExecutor<impl nexum_apdu_core::CardTransport>,
     aid_hex: &str,
 ) -> Result<String, Error> {
     let aid = hex::decode(aid_hex).map_err(|_| Error::Parse("Invalid AID hex"))?;

--- a/crates/pcsc/examples/select_aid.rs
+++ b/crates/pcsc/examples/select_aid.rs
@@ -44,7 +44,7 @@ fn select_aid(
     println!("Selecting AID: {}", aid_hex);
 
     // Send command and receive response
-    let response = executor.transmit(&select_cmd.to_bytes())?;
+    let response = executor.transmit_raw(&select_cmd.to_bytes())?;
 
     // Parse response as a Response object
     let resp = nexum_apdu_core::Response::from_bytes(&response)?;

--- a/crates/pcsc/src/monitor.rs
+++ b/crates/pcsc/src/monitor.rs
@@ -1,4 +1,3 @@
-// apdu-rs/crates/pcsc/src/monitor.rs
 //! Monitor implementation for PC/SC events
 
 use pcsc::{Context, ReaderState, Scope, State};
@@ -13,6 +12,8 @@ use crate::event::{CardEvent, CardState, CardStatusEvent, ReaderEvent};
 
 use crate::event::channel::{CardEventSender, CardStatusEventSender, ReaderEventSender};
 
+type PreviousStates = HashMap<String, (State, Vec<u8>)>;
+
 /// Monitor for PC/SC reader and card events
 #[allow(missing_debug_implementations)]
 pub struct PcscMonitor {
@@ -21,7 +22,7 @@ pub struct PcscMonitor {
     /// Whether the monitor is running
     running: Arc<Mutex<bool>>,
     /// Previously seen card events (to avoid duplicates)
-    previous_states: Arc<Mutex<HashMap<String, (State, Vec<u8>)>>>,
+    previous_states: Arc<Mutex<PreviousStates>>,
 }
 
 // Implementation for standard library environments

--- a/crates/pcsc/src/reader.rs
+++ b/crates/pcsc/src/reader.rs
@@ -26,7 +26,7 @@ impl PcscReader {
     }
 
     /// Get the reader name
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &String {
         &self.name
     }
 

--- a/crates/pcsc/src/transport.rs
+++ b/crates/pcsc/src/transport.rs
@@ -147,9 +147,7 @@ impl PcscTransport {
 }
 
 impl CardTransport for PcscTransport {
-    type Error = TransportError;
-
-    fn do_transmit_raw(&mut self, command: &[u8]) -> Result<Bytes, Self::Error> {
+    fn do_transmit_raw(&mut self, command: &[u8]) -> Result<Bytes, TransportError> {
         // Direct transmission without transaction handling
         self.transmit_command(command).map_err(TransportError::from)
     }
@@ -158,7 +156,7 @@ impl CardTransport for PcscTransport {
         self.card.is_some()
     }
 
-    fn reset(&mut self) -> Result<(), Self::Error> {
+    fn reset(&mut self) -> Result<(), TransportError> {
         // End any active transaction
         self.transaction_active = false;
 

--- a/crates/pcsc/src/transport.rs
+++ b/crates/pcsc/src/transport.rs
@@ -166,7 +166,7 @@ impl CardTransport for PcscTransport {
         }
 
         // Try to reconnect
-        self.connect_card().map_err(TransportError::from)
+        self.connect_card().map_err(Into::into)
     }
 }
 

--- a/crates/pcsc/src/transport.rs
+++ b/crates/pcsc/src/transport.rs
@@ -99,7 +99,7 @@ impl PcscTransport {
     }
 
     /// Get the reader name
-    pub fn reader_name(&self) -> &str {
+    pub const fn reader_name(&self) -> &String {
         &self.reader_name
     }
 


### PR DESCRIPTION
This PR:

1. Revises the error types to reduce dependencies and favours "escalating" errors, providing low-level From implementations to high-level errors.
2. Allows for consumers to implement their own error type and have this as the sole type, neatly encapsulating the SDK's errors.