### PR TITLE
chore!: response data optional

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -67,9 +67,10 @@ mod tests {
         assert_eq!(cmd.p1(), 0x04);
         assert_eq!(cmd.p2(), 0x00);
 
-        let resp = Response::success(Bytes::from_static(&[0x01, 0x02, 0x03]));
+        let data = Bytes::from_static(&[0x01, 0x02, 0x03]);
+        let resp = Response::success(Some(data.clone()));
         assert!(resp.is_success());
-        assert_eq!(resp.payload(), &[0x01, 0x02, 0x03]);
+        assert_eq!(resp.payload(), &Some(data));
         assert_eq!(resp.status(), StatusWord::new(0x90, 0x00));
     }
 }

--- a/crates/core/src/response/mod.rs
+++ b/crates/core/src/response/mod.rs
@@ -55,7 +55,7 @@ impl Response {
     }
 
     /// Create a success response
-    pub fn success(payload: Option<Bytes>) -> Self {
+    pub const fn success(payload: Option<Bytes>) -> Self {
         Self {
             payload,
             status: StatusWord::new(0x90, 0x00),

--- a/crates/core/src/response/mod.rs
+++ b/crates/core/src/response/mod.rs
@@ -16,7 +16,7 @@ use status::StatusWord;
 /// Trait for APDU responses
 pub trait ApduResponse: Sized {
     /// Get the response payload data
-    fn payload(&self) -> &[u8];
+    fn payload(&self) -> &Option<Bytes>;
 
     /// Get the status word
     fn status(&self) -> StatusWord;
@@ -27,37 +27,37 @@ pub trait ApduResponse: Sized {
     }
 
     /// Create from raw APDU response data
-    fn from_bytes(data: &[u8]) -> Result<Self, ResponseError>;
+    fn from_bytes(data: &Bytes) -> Result<Self, ResponseError>;
 }
 
 /// Trait for types that can be created from APDU response data
 pub trait FromApduResponse: Sized {
     /// Convert raw APDU response data to this type
-    fn from_response(data: &[u8]) -> Result<Self, ResponseError>;
+    fn from_response(data: &Bytes) -> Result<Self, ResponseError>;
 }
 
 /// Basic APDU response structure
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Response {
     /// Response payload data
-    payload: Bytes,
+    payload: Option<Bytes>,
     /// Status word
     status: StatusWord,
 }
 
 impl Response {
     /// Create a new response with payload and status
-    pub fn new(payload: impl Into<Bytes>, status: impl Into<StatusWord>) -> Self {
+    pub fn new(payload: Option<Bytes>, status: impl Into<StatusWord>) -> Self {
         Self {
-            payload: payload.into(),
+            payload,
             status: status.into(),
         }
     }
 
-    /// Create a success response (SW=9000)
-    pub fn success(payload: impl Into<Bytes>) -> Self {
+    /// Create a success response
+    pub fn success(payload: Option<Bytes>) -> Self {
         Self {
-            payload: payload.into(),
+            payload,
             status: StatusWord::new(0x90, 0x00),
         }
     }
@@ -65,26 +65,23 @@ impl Response {
     /// Create an error response from a status word
     pub fn error(status: impl Into<StatusWord>) -> Self {
         Self {
-            payload: Bytes::new(),
+            payload: None,
             status: status.into(),
         }
     }
 
     /// Parse response from raw bytes (including status word)
-    pub fn from_bytes(data: &[u8]) -> Result<Self, ResponseError> {
+    pub fn from_bytes(data: &Bytes) -> Result<Self, ResponseError> {
         let (status, payload) = utils::extract_status_and_payload(data)?;
 
         trace!(
             sw1 = format_args!("{:#04x}", status.sw1),
             sw2 = format_args!("{:#04x}", status.sw2),
-            payload_len = payload.len(),
+            payload_len = payload.as_ref().map_or(0, |p| p.len()),
             "Parsed APDU response"
         );
 
-        Ok(Self {
-            payload: Bytes::copy_from_slice(payload),
-            status,
-        })
+        Ok(Self { payload, status })
     }
 
     /// Get the status word as a tuple (SW1, SW2)
@@ -93,7 +90,7 @@ impl Response {
     }
 
     /// Convert to a bytes result
-    pub fn into_bytes_result(self) -> Result<Bytes, StatusError> {
+    pub fn into_bytes_result(self) -> Result<Option<Bytes>, StatusError> {
         if self.is_success() {
             Ok(self.payload)
         } else {
@@ -102,7 +99,7 @@ impl Response {
     }
 
     /// Convert to a bytes reference result
-    pub fn as_bytes_result(&self) -> Result<&[u8], ResponseError> {
+    pub fn as_bytes_result(&self) -> Result<&Option<Bytes>, ResponseError> {
         if self.is_success() {
             Ok(&self.payload)
         } else {
@@ -112,7 +109,7 @@ impl Response {
 }
 
 impl ApduResponse for Response {
-    fn payload(&self) -> &[u8] {
+    fn payload(&self) -> &Option<Bytes> {
         &self.payload
     }
 
@@ -120,7 +117,7 @@ impl ApduResponse for Response {
         self.status
     }
 
-    fn from_bytes(data: &[u8]) -> Result<Self, ResponseError> {
+    fn from_bytes(data: &Bytes) -> Result<Self, ResponseError> {
         Self::from_bytes(data)
     }
 }
@@ -129,7 +126,7 @@ impl TryFrom<&[u8]> for Response {
     type Error = ResponseError;
 
     fn try_from(data: &[u8]) -> Result<Self, ResponseError> {
-        Self::from_bytes(data)
+        Self::from_bytes(&Bytes::copy_from_slice(data))
     }
 }
 
@@ -144,19 +141,13 @@ impl TryFrom<Bytes> for Response {
 
 impl From<Response> for Bytes {
     fn from(response: Response) -> Self {
-        let mut buf = BytesMut::with_capacity(response.payload.len() + 2);
-        buf.put_slice(&response.payload);
+        let mut buf = BytesMut::with_capacity(response.payload.as_ref().map_or(0, |p| p.len()) + 2);
+        if let Some(payload) = response.payload {
+            buf.put_slice(&payload);
+        }
         buf.put_u8(response.status.sw1);
         buf.put_u8(response.status.sw2);
         buf.freeze()
-    }
-}
-
-// Support converting to Vec for compatibility
-impl From<Response> for Vec<u8> {
-    fn from(response: Response) -> Self {
-        let bytes: Bytes = response.into();
-        bytes.to_vec()
     }
 }
 
@@ -166,39 +157,48 @@ mod tests {
 
     #[test]
     fn test_response_creation() {
-        let data = &[0x01, 0x02, 0x03][..];
-        let resp = Response::new(Bytes::copy_from_slice(data), (0x90, 0x00));
-        assert_eq!(resp.payload(), &[0x01, 0x02, 0x03]);
+        let data = Some(Bytes::from_static(&[0x01, 0x02, 0x03][..]));
+        let resp = Response::new(data, (0x90, 0x00));
+        assert_eq!(
+            resp.payload(),
+            &Some(Bytes::from_static(&[0x01, 0x02, 0x03]))
+        );
         assert_eq!(resp.status(), StatusWord::new(0x90, 0x00));
         assert!(resp.is_success());
     }
 
     #[test]
     fn test_response_from_bytes() {
-        let data = [0x01, 0x02, 0x03, 0x90, 0x00];
+        let data = Bytes::from_static(&[0x01, 0x02, 0x03, 0x90, 0x00]);
         let resp = Response::from_bytes(&data).unwrap();
-        assert_eq!(resp.payload(), &[0x01, 0x02, 0x03]);
+        assert_eq!(
+            resp.payload().as_ref().unwrap().as_ref(),
+            &[0x01, 0x02, 0x03]
+        );
         assert_eq!(resp.status(), StatusWord::new(0x90, 0x00));
         assert!(resp.is_success());
 
-        let data = [0x90, 0x00];
+        let data = Bytes::from_static(&[0x90, 0x00]);
         let resp = Response::from_bytes(&data).unwrap();
-        assert_eq!(resp.payload(), &[]);
+        assert!(resp.payload().is_none());
         assert_eq!(resp.status(), StatusWord::new(0x90, 0x00));
         assert!(resp.is_success());
 
-        let data = [0x01];
+        let data = Bytes::from_static(&[0x01]);
         assert!(Response::from_bytes(&data).is_err());
     }
 
     #[test]
     fn test_response_into_result() {
-        let data = &[0x01, 0x02, 0x03][..];
-        let success = Response::success(Bytes::copy_from_slice(data));
+        let data = Bytes::from_static(&[0x01, 0x02, 0x03][..]);
+        let success = Response::success(Some(data));
 
         let result = success.into_bytes_result();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().as_ref(), &[0x01, 0x02, 0x03]);
+        assert_eq!(
+            result.unwrap().as_ref(),
+            Some(&Bytes::from_static(&[0x01, 0x02, 0x03]))
+        );
 
         let error = Response::error((0x6A, 0x82));
         let result = error.into_bytes_result();

--- a/crates/core/src/response/utils.rs
+++ b/crates/core/src/response/utils.rs
@@ -2,6 +2,7 @@
 
 use crate::response::error::ResponseError;
 use crate::response::status::StatusWord;
+use bytes::Bytes;
 use tracing::debug;
 
 /// Extract status word (SW1, SW2) and payload from raw APDU response data
@@ -12,18 +13,20 @@ use tracing::debug;
 ///
 /// # Errors
 /// Returns an error if the data is too short to contain a valid status word.
-pub fn extract_response_parts(data: &[u8]) -> Result<((u8, u8), &[u8]), ResponseError> {
+pub fn extract_response_parts(data: &Bytes) -> Result<((u8, u8), Option<Bytes>), ResponseError> {
     if data.len() < 2 {
         debug!("Response too short: {} bytes", data.len());
         return Err(ResponseError::BufferTooSmall);
     }
 
     let len = data.len();
-    let sw1 = data[len - 2];
-    let sw2 = data[len - 1];
-    let payload = if len > 2 { &data[..len - 2] } else { &[] };
-
-    Ok(((sw1, sw2), payload))
+    match len {
+        2 => Ok(((data[0], data[1]), None)),
+        _ => Ok((
+            (data[len - 2], data[len - 1]),
+            Some(Bytes::copy_from_slice(&data[..len - 2])),
+        )),
+    }
 }
 
 /// Extract status word as a StatusWord object and payload from raw APDU response data
@@ -34,7 +37,9 @@ pub fn extract_response_parts(data: &[u8]) -> Result<((u8, u8), &[u8]), Response
 ///
 /// # Errors
 /// Returns an error if the data is too short to contain a valid status word.
-pub fn extract_status_and_payload(data: &[u8]) -> Result<(StatusWord, &[u8]), ResponseError> {
+pub fn extract_status_and_payload(
+    data: &Bytes,
+) -> Result<(StatusWord, Option<Bytes>), ResponseError> {
     let ((sw1, sw2), payload) = extract_response_parts(data)?;
     Ok((StatusWord::new(sw1, sw2), payload))
 }
@@ -46,34 +51,34 @@ mod tests {
     #[test]
     fn test_extract_response_parts() {
         // Test with payload and status
-        let data = [0x01, 0x02, 0x03, 0x90, 0x00];
+        let data = Bytes::from_static(&[0x01, 0x02, 0x03, 0x90, 0x00]);
         let result = extract_response_parts(&data).unwrap();
         assert_eq!(result.0, (0x90, 0x00));
-        assert_eq!(result.1, &[0x01, 0x02, 0x03]);
+        assert_eq!(result.1, Some(Bytes::from_static(&[0x01, 0x02, 0x03])));
 
         // Test with only status
-        let data = [0x90, 0x00];
+        let data = Bytes::from_static(&[0x90, 0x00]);
         let result = extract_response_parts(&data).unwrap();
         assert_eq!(result.0, (0x90, 0x00));
-        assert_eq!(result.1, &[]);
+        assert_eq!(result.1, None);
 
         // Test with insufficient data
-        let data = [0x90];
+        let data = Bytes::from_static(&[0x90]);
         assert!(extract_response_parts(&data).is_err());
     }
 
     #[test]
     fn test_extract_status_and_payload() {
         // Test with payload and status
-        let data = [0x01, 0x02, 0x03, 0x90, 0x00];
+        let data = Bytes::from_static(&[0x01, 0x02, 0x03, 0x90, 0x00]);
         let result = extract_status_and_payload(&data).unwrap();
         assert_eq!(result.0, StatusWord::new(0x90, 0x00));
-        assert_eq!(result.1, &[0x01, 0x02, 0x03]);
+        assert_eq!(result.1, Some(Bytes::from_static(&[0x01, 0x02, 0x03])));
 
         // Test with only status
-        let data = [0x90, 0x00];
+        let data = Bytes::from_static(&[0x90, 0x00]);
         let result = extract_status_and_payload(&data).unwrap();
         assert_eq!(result.0, StatusWord::new(0x90, 0x00));
-        assert_eq!(result.1, &[]);
+        assert_eq!(result.1, None);
     }
 }

--- a/crates/globalplatform/src/lib.rs
+++ b/crates/globalplatform/src/lib.rs
@@ -53,7 +53,7 @@ impl DefaultGlobalPlatform {
             .open_reader_with_config(reader_name, config)
             .map_err(TransportError::from)?;
         let executor = CardExecutor::new(transport);
-        Ok(GlobalPlatform::new(executor))
+        Ok(Self::new(executor))
     }
 }
 

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -231,6 +231,10 @@ impl CommandProcessor for GPSecureChannel {
     fn is_active(&self) -> bool {
         self.established
     }
+
+    fn security_level(&self) -> SecurityLevel {
+        self.security_level
+    }
 }
 
 impl SecureChannel for GPSecureChannel {

--- a/crates/globalplatform/src/secure_channel.rs
+++ b/crates/globalplatform/src/secure_channel.rs
@@ -249,8 +249,7 @@ impl SecureChannel for GPSecureChannel {
         warn!("Reestablish not implemented for GlobalPlatform SCP02");
         Err(SecureProtocolError::Session(
             "Cannot reestablish GlobalPlatform SCP02 channel - a new session must be created",
-        )
-        .into())
+        ))
     }
 }
 

--- a/crates/pcsc/examples/apdu_shell.rs
+++ b/crates/pcsc/examples/apdu_shell.rs
@@ -144,18 +144,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Execute command
                 match executor.transmit_raw(&select_cmd.to_bytes()) {
-                    Ok(response_bytes) => {
-                        // Clone to avoid borrow issues with Response::from_bytes
-                        let response_data = response_bytes.to_vec();
-                        match Response::from_bytes(&response_data) {
-                            Ok(response) => {
-                                println!("Response:");
-                                println!("  Status: {}", response.status());
-                                println!("  Data: {}", hex::encode_upper(response.payload()));
+                    Ok(response_bytes) => match Response::from_bytes(&response_bytes) {
+                        Ok(response) => {
+                            println!("Response:");
+                            println!("  Status: {}", response.status());
+                            match response.payload() {
+                                Some(payload) => println!("  Data: {}", hex::encode_upper(payload)),
+                                None => println!("  Data: None"),
                             }
-                            Err(e) => println!("Error parsing response: {:?}", e),
                         }
-                    }
+                        Err(e) => println!("Error parsing response: {:?}", e),
+                    },
                     Err(e) => println!("Command failed: {:?}", e),
                 }
             }
@@ -177,16 +176,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match executor.transmit_raw(&command_bytes) {
                             Ok(response_bytes) => {
                                 // Clone to avoid borrow issues with Response::from_bytes
-                                let response_data = response_bytes.to_vec();
-                                match Response::from_bytes(&response_data) {
+                                match Response::from_bytes(&response_bytes) {
                                     Ok(response) => {
                                         println!("Response:");
                                         println!("  Status: {}", response.status());
-                                        if !response.payload().is_empty() {
-                                            println!(
-                                                "  Data: {}",
-                                                hex::encode_upper(response.payload())
-                                            );
+                                        if let Some(payload) = response.payload() {
+                                            println!("  Data: {}", hex::encode_upper(payload));
                                         }
                                     }
                                     Err(e) => println!("Error parsing response: {:?}", e),

--- a/crates/pcsc/examples/connect.rs
+++ b/crates/pcsc/examples/connect.rs
@@ -64,19 +64,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("\nSending {}: {}", name, hex);
 
         match executor.transmit_raw(&cmd_bytes) {
-            Ok(response_bytes) => {
-                let response_data = response_bytes.to_vec();
-                match Response::from_bytes(&response_data) {
-                    Ok(response) => {
-                        println!("Response:");
-                        println!("  Status: {}", response.status());
-                        if !response.payload().is_empty() {
-                            println!("  Data: {}", hex::encode_upper(response.payload()));
-                        }
+            Ok(response_bytes) => match Response::from_bytes(&response_bytes) {
+                Ok(response) => {
+                    println!("Response:");
+                    println!("  Status: {}", response.status());
+                    if let Some(payload) = response.payload() {
+                        println!("  Data: {}", hex::encode_upper(payload));
                     }
-                    Err(e) => println!("Error parsing response: {:?}", e),
                 }
-            }
+                Err(e) => println!("Error parsing response: {:?}", e),
+            },
             Err(e) => println!("Command failed: {:?}", e),
         }
 

--- a/crates/pcsc/examples/select_aid.rs
+++ b/crates/pcsc/examples/select_aid.rs
@@ -52,7 +52,7 @@ fn select_aid(
     if resp.is_success() {
         Ok(format!(
             "Selected successfully, {} data bytes returned",
-            resp.payload().len()
+            resp.payload().as_ref().map_or(0, |payload| payload.len())
         ))
     } else {
         Ok(format!("Selection failed: {}", resp.status()))


### PR DESCRIPTION
This PR:

1. Ensures that the response data must contain at least a status word, but if any payload is returned, this is `Some(Bytes)`, with no payload returned being interpreted as `None`.
2. Ensures the security level accessor is implemented for GlobalPlatform.

Fixes: #28, #27 