### PR TITLE
chore!: rust native return type for command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ nexum-apdu-transport-pcsc = { version = "0.1.0", path = "crates/pcsc" }
 pcsc = { version = "2.9.0", default-features = false }
 
 ## misc
-bytes = { version = "1.9.0", default-features = false }
+bytes = { version = "1.10", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 iso7816-tlv = { version = "0.4.4" }
 
@@ -82,4 +82,4 @@ tracing-subscriber = { version = "0.3", default-features = false }
 
 ## misc
 clap = { version = "4.5" }
-zip = { version = "2.5", default-features = false }
+zip = { version = "2.6", default-features = false }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod prelude {
     // Command related
     pub use crate::{
         Command,
-        command::{ApduCommand, CommandResult, ExpectedLength},
+        command::{ApduCommand, ExpectedLength},
     };
 
     // Response related

--- a/crates/globalplatform/src/application.rs
+++ b/crates/globalplatform/src/application.rs
@@ -67,7 +67,7 @@ where
             self.last_response = Some(Bytes::copy_from_slice(raw_response));
         }
 
-        response.map_err(Into::into)
+        Ok(response)
     }
 
     /// Open a secure channel with default keys
@@ -87,25 +87,25 @@ where
     /// Delete an object
     pub fn delete_object(&mut self, aid: &[u8]) -> Result<DeleteOk> {
         let cmd = DeleteCommand::delete_object(aid);
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Delete an object and related objects
     pub fn delete_object_and_related(&mut self, aid: &[u8]) -> Result<DeleteOk> {
         let cmd = DeleteCommand::delete_object_and_related(aid);
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Get the status of applications
     pub fn get_applications_status(&mut self) -> Result<GetStatusOk> {
         let cmd = GetStatusCommand::all_with_type(get_status_p1::APPLICATIONS);
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Get the status of load files
     pub fn get_load_files_status(&mut self) -> Result<GetStatusOk> {
         let cmd = GetStatusCommand::all_with_type(get_status_p1::EXEC_LOAD_FILES);
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Install a package for load
@@ -118,7 +118,7 @@ where
         let sd_aid = security_domain_aid.unwrap_or(SECURITY_DOMAIN_AID);
 
         let cmd = InstallCommand::for_load(package_aid, sd_aid);
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Install for install and make selectable
@@ -141,7 +141,7 @@ where
             &[] as &[u8], // Empty token
         );
 
-        self.executor.execute(&cmd)?.map_err(Into::into)
+        self.executor.execute(&cmd).map_err(Into::into)
     }
 
     /// Load a CAP file
@@ -171,7 +171,7 @@ where
             // Execute command
             let _ = self
                 .executor
-                .execute(&cmd)?
+                .execute(&cmd)
                 .map_err(|_| Error::Other("Load failed"))?;
 
             // Call callback if provided
@@ -324,7 +324,7 @@ where
         // Execute the command
         let _ = self
             .executor
-            .execute(&cmd)?
+            .execute(&cmd)
             .map_err(|_| Error::Other("Personalization failed"))?;
 
         Ok(())

--- a/crates/globalplatform/src/commands/delete.rs
+++ b/crates/globalplatform/src/commands/delete.rs
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_delete_command() {
@@ -99,15 +99,12 @@ mod tests {
     fn test_delete_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = DeleteResult::from_bytes(&response_data).unwrap();
-        assert!(matches!((*result).as_ref().unwrap(), DeleteOk::Success));
+        let result = DeleteCommand::parse_response_raw(response_data).unwrap();
+        assert!(matches!(result, DeleteOk::Success));
 
         // Test error response
         let error_data = Bytes::from_static(&hex!("6A88"));
-        let error_result = DeleteResult::from_bytes(&error_data).unwrap();
-        assert!(matches!(
-            (*error_result).as_ref().unwrap_err(),
-            DeleteError::ReferencedDataNotFound
-        ));
+        let error_result = DeleteCommand::parse_response_raw(error_data).unwrap_err();
+        assert!(matches!(error_result, DeleteError::ReferencedDataNotFound));
     }
 }

--- a/crates/globalplatform/src/commands/external_authenticate.rs
+++ b/crates/globalplatform/src/commands/external_authenticate.rs
@@ -64,7 +64,7 @@ mod tests {
     use bytes::Bytes;
     use cipher::Key;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_external_authenticate_command() {
@@ -110,17 +110,14 @@ mod tests {
     fn test_external_authenticate_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = ExternalAuthenticateResult::from_bytes(&response_data).unwrap();
-        assert!(matches!(
-            (*result).as_ref().unwrap(),
-            ExternalAuthenticateOk::Success
-        ));
+        let ok = ExternalAuthenticateCommand::parse_response_raw(response_data).unwrap();
+        assert!(matches!(ok, ExternalAuthenticateOk::Success));
 
         // Test error response
         let error_data = Bytes::from_static(&hex!("6982"));
-        let error_result = ExternalAuthenticateResult::from_bytes(&error_data).unwrap();
+        let error_result = ExternalAuthenticateCommand::parse_response_raw(error_data).unwrap_err();
         assert!(matches!(
-            (*error_result).as_ref().unwrap_err(),
+            error_result,
             ExternalAuthenticateError::SecurityStatusNotSatisfied
         ));
     }

--- a/crates/globalplatform/src/commands/get_response.rs
+++ b/crates/globalplatform/src/commands/get_response.rs
@@ -78,7 +78,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_get_response_command() {
@@ -100,10 +100,7 @@ mod tests {
     fn test_get_response_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("010203049000"));
-        let result = GetResponseResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetResponseCommand::parse_response_raw(response_data).unwrap();
 
         assert!(matches!(result, GetResponseOk::Success { .. }));
         assert_eq!(result.data(), &hex!("01020304")[..].to_vec());
@@ -112,10 +109,7 @@ mod tests {
 
         // Test more data available
         let response_data = Bytes::from_static(&hex!("0102030461FF"));
-        let result = GetResponseResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetResponseCommand::parse_response_raw(response_data).unwrap();
 
         assert!(matches!(result, GetResponseOk::MoreData { .. }));
         assert_eq!(result.data(), &hex!("01020304")[..].to_vec());

--- a/crates/globalplatform/src/commands/get_status.rs
+++ b/crates/globalplatform/src/commands/get_status.rs
@@ -251,7 +251,7 @@ mod tests {
     use super::*;
     use bytes::{BufMut, BytesMut};
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_get_status_command() {
@@ -289,10 +289,7 @@ mod tests {
         buf.put(tlv_data.as_ref());
         buf.put(hex!("9000").as_ref());
 
-        let result = GetStatusResult::from_bytes(&buf.freeze())
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetStatusCommand::parse_response_raw(buf.freeze()).unwrap();
         assert!(matches!(result, GetStatusOk::Success { .. }));
         assert_eq!(result.tlv_data(), &tlv_data.to_vec());
         assert!(!result.has_more_data());
@@ -303,10 +300,7 @@ mod tests {
         buf.put(tlv_data.as_ref());
         buf.put(hex!("6120").as_ref());
 
-        let result = GetStatusResult::from_bytes(&buf.freeze())
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetStatusCommand::parse_response_raw(buf.freeze()).unwrap();
         assert!(matches!(result, GetStatusOk::MoreData { .. }));
         assert_eq!(result.tlv_data(), &tlv_data.to_vec());
         assert!(result.has_more_data());
@@ -322,10 +316,7 @@ mod tests {
             "9000"
         ));
 
-        let result = GetStatusResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetStatusCommand::parse_response_raw(response_data).unwrap();
 
         // Parse applications
         let apps = parse_applications(result);
@@ -356,10 +347,7 @@ mod tests {
             "9000"
         ));
 
-        let result = GetStatusResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = GetStatusCommand::parse_response_raw(response_data).unwrap();
 
         // Parse load files
         let files = parse_load_files(result);

--- a/crates/globalplatform/src/commands/initialize_update.rs
+++ b/crates/globalplatform/src/commands/initialize_update.rs
@@ -146,7 +146,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_initialize_update_command() {
@@ -172,10 +172,7 @@ mod tests {
             "000002650183039536622002000de9c62ba1c4c8e55fcb91b6654ce49000"
         ));
 
-        let result = InitializeUpdateResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = InitializeUpdateCommand::parse_response_raw(response_data).unwrap();
 
         assert!(matches!(result, InitializeUpdateOk::Success { .. }));
         assert_eq!(result.scp_version(), Some(0x02));
@@ -206,11 +203,9 @@ mod tests {
 
         // Test error response
         let response_data = Bytes::from_static(&hex!("6982"));
-        let result = InitializeUpdateResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner();
+        let result = InitializeUpdateCommand::parse_response_raw(response_data).unwrap_err();
         assert!(matches!(
-            result.unwrap_err(),
+            result,
             InitializeUpdateError::SecurityStatusNotSatisfied
         ));
     }

--- a/crates/globalplatform/src/commands/install.rs
+++ b/crates/globalplatform/src/commands/install.rs
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_install_for_load() {
@@ -255,18 +255,12 @@ mod tests {
     fn test_install_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = InstallResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = InstallCommand::parse_response_raw(response_data).unwrap();
         assert!(matches!(result, InstallOk::Success));
 
         // Test error response
         let response_data = Bytes::from_static(&hex!("6982"));
-        let response = InstallResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap_err();
+        let response = InstallCommand::parse_response_raw(response_data).unwrap_err();
         assert!(matches!(response, InstallError::SecurityStatusNotSatisfied));
     }
 }

--- a/crates/globalplatform/src/commands/load.rs
+++ b/crates/globalplatform/src/commands/load.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_load_command() {
@@ -90,18 +90,12 @@ mod tests {
     fn test_load_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = LoadResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = LoadCommand::parse_response_raw(response_data).unwrap();
         assert!(matches!(result, LoadOk::Success));
 
         // Test error response
         let response_data = Bytes::from_static(&hex!("6982"));
-        let result = LoadResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap_err();
+        let result = LoadCommand::parse_response_raw(response_data).unwrap_err();
         assert!(matches!(result, LoadError::SecurityStatusNotSatisfied));
     }
 }

--- a/crates/globalplatform/src/commands/put_key.rs
+++ b/crates/globalplatform/src/commands/put_key.rs
@@ -69,7 +69,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_put_key_command() {
@@ -92,18 +92,12 @@ mod tests {
     fn test_put_key_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = PutKeyResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = PutKeyCommand::parse_response_raw(response_data).unwrap();
         assert!(matches!(result, PutKeyOk::Success));
 
         // Test error response
         let response_data = Bytes::from_static(&hex!("6982"));
-        let response = PutKeyResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap_err();
+        let response = PutKeyCommand::parse_response_raw(response_data).unwrap_err();
         assert!(matches!(response, PutKeyError::SecurityStatusNotSatisfied));
     }
 }

--- a/crates/globalplatform/src/commands/select.rs
+++ b/crates/globalplatform/src/commands/select.rs
@@ -219,7 +219,7 @@ mod tests {
     use super::*;
     use bytes::{BufMut, BytesMut};
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_select_command() {
@@ -247,18 +247,12 @@ mod tests {
         buf.put(fci_data.as_ref());
         buf.put(hex!("9000").as_ref());
 
-        let result = SelectResult::from_bytes(&buf.freeze())
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = SelectCommand::parse_response_raw(buf.freeze()).unwrap();
         assert_eq!(result.fci(), fci_data.as_slice());
 
         // Test file not found
         let response_data = Bytes::from_static(&hex!("6A82"));
-        let result = SelectResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap_err();
+        let result = SelectCommand::parse_response_raw(response_data).unwrap_err();
         assert_eq!(result, SelectError::NotFound);
     }
 }

--- a/crates/globalplatform/src/commands/store_data.rs
+++ b/crates/globalplatform/src/commands/store_data.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use hex_literal::hex;
-    use nexum_apdu_core::{ApduCommand, ApduResponse};
+    use nexum_apdu_core::ApduCommand;
 
     #[test]
     fn test_store_data_command() {
@@ -114,18 +114,12 @@ mod tests {
     fn test_store_data_response() {
         // Test successful response
         let response_data = Bytes::from_static(&hex!("9000"));
-        let result = StoreDataResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let result = StoreDataCommand::parse_response_raw(response_data).unwrap();
         assert!(matches!(result, StoreDataOk::Success));
 
         // Test error response
         let response_data = Bytes::from_static(&hex!("6A80"));
-        let result = StoreDataResult::from_bytes(&response_data)
-            .unwrap()
-            .into_inner()
-            .unwrap_err();
+        let result = StoreDataCommand::parse_response_raw(response_data).unwrap_err();
         assert!(matches!(result, StoreDataError::WrongData));
     }
 }

--- a/crates/macros/examples/get_data.rs
+++ b/crates/macros/examples/get_data.rs
@@ -105,7 +105,7 @@ fn main() {
     let result = GetDataCommand::parse_response_raw(response_bytes);
 
     // Convert to inner result and use our custom methods
-    match result.clone() {
+    match &result {
         Ok(ok) => {
             println!("Success! Data: {:?}", ok.data());
             if let Some(remaining) = ok.remaining_bytes() {

--- a/crates/macros/examples/get_data.rs
+++ b/crates/macros/examples/get_data.rs
@@ -102,10 +102,10 @@ fn main() {
 
     // Simulate a successful response
     let response_bytes = Bytes::from_static(&[0x01, 0x02, 0x03, 0x04, 0x90, 0x00]);
-    let result = GetDataResult::from_bytes(&response_bytes).unwrap();
+    let result = GetDataCommand::parse_response_raw(response_bytes);
 
     // Convert to inner result and use our custom methods
-    match result.clone().into_inner() {
+    match result.clone() {
         Ok(ok) => {
             println!("Success! Data: {:?}", ok.data());
             if let Some(remaining) = ok.remaining_bytes() {
@@ -124,9 +124,9 @@ fn main() {
     }
 
     // Example of using ? operator with the result
-    fn process_response(response: GetDataResult) -> Result<Vec<u8>, GetDataError> {
+    fn process_response(result: Result<GetDataOk, GetDataError>) -> Result<Vec<u8>, GetDataError> {
         // Get the inner result and use ?
-        let ok = response.into_inner()?;
+        let ok = result?;
 
         // Use our custom method
         let data = ok.data().to_vec();

--- a/crates/macros/examples/read_record.rs
+++ b/crates/macros/examples/read_record.rs
@@ -106,10 +106,10 @@ fn main() {
     ];
     let response_bytes = Bytes::from([&record_data[..], &[0x90, 0x00]].concat());
 
-    let result = ReadRecordResult::from_bytes(&response_bytes).unwrap();
+    let result = ReadRecordCommand::parse_response_raw(response_bytes);
 
     // Using our custom methods on the unwrapped result
-    match result.into_inner() {
+    match result {
         Ok(ok) => {
             println!("Record data: {:02X?}", ok.record_data());
         }
@@ -161,16 +161,15 @@ fn main() {
                 ];
                 let response_bytes = Bytes::from([&record_data[..], &[0x90, 0x00]].concat());
 
-                ReadRecordResult::from_bytes(&response_bytes)
+                ReadRecordCommand::parse_response_raw(response_bytes)
             } else {
                 // Simulate end of records for record 4+
                 let response_bytes = Bytes::from_static(&[0x6A, 0x83]);
-                ReadRecordResult::from_bytes(&response_bytes)
-            }
-            .unwrap();
+                ReadRecordCommand::parse_response_raw(response_bytes)
+            };
 
             // Use the ? operator directly on the result
-            match result.into_inner() {
+            match result {
                 Ok(ok) => {
                     records.push(ok.record_data().to_vec());
                     record_number += 1;

--- a/crates/macros/examples/select.rs
+++ b/crates/macros/examples/select.rs
@@ -96,9 +96,7 @@ fn main() {
     let response_bytes = Bytes::from([&fci_data[..], &[0x90, 0x00]].concat());
 
     // Parse raw bytes to SelectResult - now with improved error handling
-    let result = SelectResult::from_bytes(&response_bytes)
-        .unwrap()
-        .into_inner();
+    let result = SelectCommand::parse_response_raw(response_bytes);
 
     // Use our custom method on SelectOk when unwrapping
     match result {
@@ -135,10 +133,7 @@ fn main() {
         let response_bytes = Bytes::from([&fci_data[..], &[0x90, 0x00]].concat());
 
         // Parse the bytes directly - no need for ? since from_bytes returns SelectResult
-        let result = SelectResult::from_bytes(&response_bytes).unwrap();
-
-        // Use into_inner() and ? on the inner Result
-        let ok = result.into_inner()?;
+        let ok = SelectCommand::parse_response_raw(response_bytes)?;
 
         // Process the successful variant
         match ok {
@@ -159,10 +154,10 @@ fn main() {
 
     // Demonstrate handling unknown status words
     let unknown_response = Bytes::from_static(&[0x69, 0x85]);
-    let unknown_result = SelectResult::from_bytes(&unknown_response);
+    let unknown_result = SelectCommand::parse_response_raw(unknown_response);
 
     // The error is now inside the result, not wrapping it
-    match unknown_result.unwrap().into_inner() {
+    match unknown_result {
         Ok(_) => println!("Unexpected success"),
         Err(SelectError::Unknown { sw1, sw2 }) => {
             println!("Handled unknown status word: {:02X}{:02X}", sw1, sw2);

--- a/crates/macros/src/command.rs
+++ b/crates/macros/src/command.rs
@@ -88,7 +88,9 @@ pub(crate) fn expand_command(
     command: &CommandDef,
     vis: &Visibility,
     command_name: &Ident,
-    result_name: &Ident,
+    ok_name: &Ident,
+    error_name: &Ident,
+    parse_impl: &TokenStream,
 ) -> Result<TokenStream, syn::Error> {
     let cla = &command.cla;
     let ins = &command.ins;
@@ -139,7 +141,8 @@ pub(crate) fn expand_command(
         }
 
         impl nexum_apdu_core::ApduCommand for #command_name {
-            type Response = #result_name;
+            type Success = #ok_name;
+            type Error = #error_name;
 
             fn class(&self) -> u8 {
                 #cla
@@ -168,6 +171,9 @@ pub(crate) fn expand_command(
             fn required_security_level(&self) -> SecurityLevel {
                 #required_security_level
             }
+
+            // Parse response implementation
+            #parse_impl
         }
     };
 


### PR DESCRIPTION
This PR:

1. Removes the newtype wrapper for the result expected and instead returns native `Result<T, E>`.